### PR TITLE
Read VS manifest mirror via git partial clone; cas + TLS fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfb"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +254,22 @@ dependencies = [
  "time",
  "url",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -698,6 +730,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +966,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1156,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1175,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1098,6 +1219,47 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1474,6 +1636,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "ureq-proto",
@@ -1545,6 +1708,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1660,6 +1833,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,10 +1851,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1712,6 +1912,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
@@ -1743,6 +1958,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -1755,6 +1976,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -1764,6 +1991,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1785,6 +2018,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -1794,6 +2033,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1809,6 +2054,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -1818,6 +2069,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-ureq = { version = "3.1.4", features = ["json"] }
+ureq = { version = "3.1.4", features = ["json", "platform-verifier"] }
 url = "2.5"
 uuid = { version = "1", features = ["v4"] }
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -21,6 +21,10 @@ pub struct Cache {
     pub cas: PathBuf,
     pub downloads: PathBuf,
     pub staging: PathBuf,
+    /// Persistent auxiliary data that isn't an install, a CAS blob, or a
+    /// downloaded artifact — currently the bare git clone of the VS
+    /// manifest-history mirror under `meta/msvc-manifest-history`.
+    pub meta: PathBuf,
 }
 
 impl Cache {
@@ -52,12 +56,14 @@ impl Cache {
         let cas = root.join("cas");
         let downloads = root.join("downloads");
         let staging = root.join("staging");
+        let meta = root.join("meta");
         Self {
             root,
             installs,
             cas,
             downloads,
             staging,
+            meta,
         }
     }
 
@@ -67,7 +73,7 @@ impl Cache {
     pub fn ensure_layout(&self) -> Result<()> {
         std::fs::create_dir_all(&self.root)
             .with_context(|| format!("creating cache root {}", self.root.display()))?;
-        for d in [&self.installs, &self.cas, &self.downloads, &self.staging] {
+        for d in [&self.installs, &self.cas, &self.downloads, &self.staging, &self.meta] {
             std::fs::create_dir_all(d)
                 .with_context(|| format!("creating {}", d.display()))?;
         }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,4 @@
-//! Global cache layout: `installs/`, `cas/`, `downloads/`, `staging/`.
+//! Global cache layout: `installs/`, `cas/`, `downloads/`, `staging/`, `meta/`.
 //!
 //! Also owns fingerprint sanitization and the per-install `metadata.toml`
 //! schema (read + write).
@@ -67,9 +67,10 @@ impl Cache {
         }
     }
 
-    /// Create all four subdirectories if missing. Verifies they share a
-    /// filesystem volume (engine guarantees this since they're siblings of
-    /// `root`, but we double-check on first init).
+    /// Create the cache root and its subdirectories if missing. They are all
+    /// siblings of `root`, so they share a filesystem volume — which is what
+    /// lets the CAS hardlink blobs into install trees and stage files via
+    /// hardlink rather than copy.
     pub fn ensure_layout(&self) -> Result<()> {
         std::fs::create_dir_all(&self.root)
             .with_context(|| format!("creating cache root {}", self.root.display()))?;

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -2,10 +2,14 @@
 //! with xxhash3-128, places exactly one copy in `cache/cas/<aa>/<bb...>`,
 //! and hardlinks each install-tree path to that CAS file.
 //!
-//! Atomicity: each CAS insertion is a `rename(staging_file, cas_path)`. If
-//! the target already exists (peer beat us, or a previous install already
-//! owned this content), we byte-compare to confirm equality and discard our
-//! staging copy. Hash collisions are detected — never silently corrupt.
+//! Atomicity: each CAS insertion publishes the staging file by
+//! `hard_link(staging_file, cas_path)`, then drops the staging name. `link`
+//! never overwrites: if the target already exists (peer beat us, or a previous
+//! install already owned this content) it fails with `AlreadyExists` and we
+//! byte-compare to confirm equality and discard our staging copy. Because a
+//! published blob's dentry is never replaced, a peer concurrently hardlinking
+//! that blob into its install tree can't observe a torn/missing slot. Hash
+//! collisions are detected — never silently corrupt.
 
 use anyhow::{Context, Result, anyhow};
 use std::fs::File;
@@ -28,8 +32,8 @@ pub struct CasReport {
 
 /// Run the CAS pass:
 ///   1. walk `staging_raw` (the dir the provider wrote to)
-///   2. for each regular file: xxhash3-128, rename into CAS (byte-compare on
-///      EEXIST), hardlink CAS→`staging_tree/<relpath>`
+///   2. for each regular file: xxhash3-128, publish into CAS via hardlink
+///      (byte-compare on EEXIST), hardlink CAS→`staging_tree/<relpath>`
 ///   3. for each directory: mkdir under `staging_tree`
 ///   4. for each symlink: reproduce under `staging_tree`
 ///
@@ -121,68 +125,56 @@ fn cas_file(
     let hex = hash_file_xxh3_128(src)?;
     let cas_path = cache.cas_path(&hex);
 
-    // Make sure the parent dir exists before any rename attempt.
+    // Make sure the parent dir exists before any link attempt.
     if let Some(parent) = cas_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    // Try to claim the CAS slot.
-    let cas_existed = cas_path.is_file();
+    // Publish our staging copy into the CAS by hardlinking it onto the cas
+    // slot. `hard_link` is non-destructive: if the slot is already populated
+    // (a peer raced us, or a prior install owns this content) it fails with
+    // `AlreadyExists` and we leave the existing blob untouched. A `rename`
+    // here would *overwrite* on POSIX, churning the blob's dentry — and a
+    // peer mid-`hard_link(cas -> install tree)` against that same slot can
+    // observe a transient ENOENT during the swap. Once a cas blob exists its
+    // dentry is now never replaced, which keeps concurrent links race-free.
     let mut just_inserted = false;
-    if cas_existed {
-        // Byte-compare to detect a (vanishingly rare) hash collision.
-        if !files_equal(src, &cas_path)? {
-            // Collision: keep src in place at dst, log loudly. Never
-            // silently corrupt.
-            tracing::error!(
-                "xxh3-128 collision on {} (cas slot {}); keeping staging copy in install tree without CAS link",
+    match std::fs::hard_link(src, &cas_path) {
+        Ok(()) => {
+            just_inserted = true;
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Slot already populated. Byte-compare to detect a (vanishingly
+            // rare) xxh3-128 collision; never silently corrupt.
+            if !files_equal(src, &cas_path)? {
+                tracing::error!(
+                    "xxh3-128 collision on {} (cas slot {}); keeping staging copy in install tree without CAS link",
+                    src.display(),
+                    cas_path.display()
+                );
+                move_into_install_tree(src, dst)?;
+                report.files_processed += 1;
+                return Ok(());
+            }
+            let size = std::fs::metadata(src).map(|m| m.len()).unwrap_or(0);
+            report.dedupe_hits += 1;
+            report.bytes_freed += size;
+        }
+        Err(err) => {
+            return Err(anyhow!(
+                "publishing {} -> {}: {err}",
                 src.display(),
                 cas_path.display()
-            );
-            move_into_install_tree(src, dst)?;
-            report.files_processed += 1;
-            return Ok(());
-        }
-        let size = std::fs::metadata(src).map(|m| m.len()).unwrap_or(0);
-        report.dedupe_hits += 1;
-        report.bytes_freed += size;
-        // Drop our staging duplicate.
-        std::fs::remove_file(src).with_context(|| {
-            format!("removing duplicate staging file {}", src.display())
-        })?;
-    } else {
-        // Try atomic rename; on EEXIST fall through to byte-compare branch
-        // (peer raced us between our existence check and rename).
-        match std::fs::rename(src, &cas_path) {
-            Ok(()) => {
-                just_inserted = true;
-            }
-            Err(err) => {
-                if cas_path.is_file() {
-                    if !files_equal(src, &cas_path)? {
-                        tracing::error!(
-                            "xxh3-128 collision (race) on {} (cas slot {}); keeping staging copy",
-                            src.display(),
-                            cas_path.display()
-                        );
-                        move_into_install_tree(src, dst)?;
-                        report.files_processed += 1;
-                        return Ok(());
-                    }
-                    let size = std::fs::metadata(src).map(|m| m.len()).unwrap_or(0);
-                    report.dedupe_hits += 1;
-                    report.bytes_freed += size;
-                    let _ = std::fs::remove_file(src);
-                } else {
-                    return Err(anyhow!(
-                        "rename {} -> {}: {err}",
-                        src.display(),
-                        cas_path.display()
-                    ));
-                }
-            }
+            ));
         }
     }
+
+    // The CAS owns the content now; drop our staging copy. On the
+    // just-inserted path `src` and `cas_path` are two names for one inode, so
+    // this just removes the redundant name; on the dedupe path `src` was a
+    // distinct copy.
+    std::fs::remove_file(src)
+        .with_context(|| format!("removing staging file {}", src.display()))?;
 
     // Hardlink CAS → install tree position. Do this BEFORE marking the CAS
     // file readonly: on Windows, marking a file's attributes momentarily

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -172,9 +172,11 @@ fn cas_file(
     // The CAS owns the content now; drop our staging copy. On the
     // just-inserted path `src` and `cas_path` are two names for one inode, so
     // this just removes the redundant name; on the dedupe path `src` was a
-    // distinct copy.
-    std::fs::remove_file(src)
-        .with_context(|| format!("removing staging file {}", src.display()))?;
+    // distinct copy. Best-effort: the content is already safely in the CAS,
+    // and the engine reaps the whole staging dir afterward, so a transient
+    // unlink failure (e.g. an AV scanner briefly holding `src` on Windows)
+    // must not abort an otherwise-successful install.
+    let _ = std::fs::remove_file(src);
 
     // Hardlink CAS → install tree position. Do this BEFORE marking the CAS
     // file readonly: on Windows, marking a file's attributes momentarily

--- a/src/cli/msvc.rs
+++ b/src/cli/msvc.rs
@@ -22,13 +22,12 @@ use crate::download;
 use crate::extract;
 use crate::providers::msvc;
 use crate::providers::vs_manifest::{
-    self, BuildIndexEntry, MirrorUrls, Package, VsVersion,
+    self, BuildIndexEntry, ManifestHistory, Package, VsVersion,
 };
 use crate::providers::InstallCtx;
 
 /// Worker pool size for parallel package extraction. Each worker
-/// downloads + unzips one package at a time. 16 matches the rest of
-/// the codebase (vs_manifest::PARALLEL_FETCH_LIMIT).
+/// downloads + unzips one package at a time.
 const EXTRACT_PARALLELISM: usize = 16;
 
 #[derive(Debug, Args)]
@@ -78,11 +77,11 @@ pub fn run(
     args: MsvcArgs,
 ) -> Result<()> {
     let ctx = build_ctx(config, cache_dir_override)?;
-    let urls = MirrorUrls::default();
+    let history = ManifestHistory::open(&vs_manifest::default_remote(), ctx.cache())?;
     match args.verb {
-        MsvcVerb::Versions(a) => run_versions(&ctx, &urls, a, &mut std::io::stdout()),
-        MsvcVerb::Packages(a) => run_packages(&ctx, &urls, a, &mut std::io::stdout()),
-        MsvcVerb::Extract(a) => run_extract(&ctx, &urls, a, &mut std::io::stdout()),
+        MsvcVerb::Versions(a) => run_versions(&history, a, &mut std::io::stdout()),
+        MsvcVerb::Packages(a) => run_packages(&history, a, &mut std::io::stdout()),
+        MsvcVerb::Extract(a) => run_extract(&ctx, &history, a, &mut std::io::stdout()),
     }
 }
 
@@ -109,8 +108,7 @@ fn parse_vs(value: &str) -> Result<VsVersion> {
 // ---- versions --------------------------------------------------------------
 
 fn run_versions(
-    ctx: &InstallCtx,
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     args: VersionsArgs,
     out: &mut dyn std::io::Write,
 ) -> Result<()> {
@@ -127,7 +125,7 @@ fn run_versions(
         first = false;
         writeln!(out, "{} (channel {})", vs.as_str(), vs.channel())?;
 
-        let entries = vs_manifest::build_index(urls, &[vs], ctx)?;
+        let entries = history.index(&[vs])?;
         if entries.is_empty() {
             writeln!(out, "  (no builds found on mirror)")?;
             continue;
@@ -148,12 +146,11 @@ fn run_versions(
 // ---- packages --------------------------------------------------------------
 
 fn run_packages(
-    ctx: &InstallCtx,
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     args: PackagesArgs,
     out: &mut dyn std::io::Write,
 ) -> Result<()> {
-    let (entry, manifest) = resolve_and_load(ctx, urls, &args.build_version)?;
+    let (entry, manifest) = resolve_and_load(history, &args.build_version)?;
     let compiler = msvc::find_primary_compiler(&manifest, entry.vs)?;
     let family = msvc::family_prefix(&compiler.id)?;
     let compiler_version = primary_version(compiler)?;
@@ -223,11 +220,11 @@ fn print_packages(out: &mut dyn std::io::Write, packages: &[&Package]) -> Result
 
 fn run_extract(
     ctx: &InstallCtx,
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     args: ExtractArgs,
     out: &mut dyn std::io::Write,
 ) -> Result<()> {
-    let (entry, manifest) = resolve_and_load(ctx, urls, &args.build_version)?;
+    let (entry, manifest) = resolve_and_load(history, &args.build_version)?;
     std::fs::create_dir_all(&args.out)
         .with_context(|| format!("creating {}", args.out.display()))?;
 
@@ -358,12 +355,11 @@ fn extract_one(pkg: &Package, dest: &Path, downloads: &Path) -> Result<()> {
 // ---- shared helpers --------------------------------------------------------
 
 fn resolve_and_load(
-    ctx: &InstallCtx,
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     build_version: &str,
 ) -> Result<(BuildIndexEntry, vs_manifest::VsManifest)> {
-    let entry = vs_manifest::resolve_build_version(urls, build_version, ctx)?;
-    let manifest = vs_manifest::fetch_manifest_at(&urls.raw_base, &entry.commit.sha, ctx)?;
+    let entry = history.resolve_build_version(build_version)?;
+    let manifest = history.manifest(&entry.commit.sha)?;
     Ok((entry, manifest))
 }
 

--- a/src/cli/tests/msvc.rs
+++ b/src/cli/tests/msvc.rs
@@ -38,8 +38,7 @@ fn versions_lists_builds_descending_per_series() {
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
     run_versions(
-        &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         VersionsArgs {
             vs: Some("vs2026".into()),
         },
@@ -98,7 +97,7 @@ fn versions_iterates_all_series_when_no_filter() {
     );
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
-    run_versions(&ctx, &fx.urls, VersionsArgs { vs: None }, &mut out).unwrap();
+    run_versions(&fx.history(&ctx), VersionsArgs { vs: None }, &mut out).unwrap();
     let s = String::from_utf8(out).unwrap();
     assert!(s.contains("vs2019 (channel 16)"), "{s}");
     assert!(s.contains("vs2022 (channel 17)"), "{s}");
@@ -131,8 +130,7 @@ fn packages_groups_family_first_then_others() {
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
     run_packages(
-        &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         PackagesArgs {
             build_version: "18.6.11819.183".into(),
         },
@@ -190,8 +188,7 @@ fn packages_excludes_other_versions_and_unrelated_workloads() {
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
     run_packages(
-        &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         PackagesArgs {
             build_version: "18.6.11819.183".into(),
         },
@@ -258,7 +255,7 @@ fn extract_excludes_other_versions_and_unrelated_workloads() {
     let mut buf = Vec::new();
     run_extract(
         &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         ExtractArgs {
             build_version: "18.6.11819.183".into(),
             out: out_dir.clone(),
@@ -295,8 +292,7 @@ fn packages_errors_on_unknown_build_version() {
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
     let err = run_packages(
-        &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         PackagesArgs {
             build_version: "18.99.99.99".into(),
         },
@@ -356,7 +352,7 @@ fn extract_writes_per_package_dirs_idempotently() {
     };
 
     let mut buf = Vec::new();
-    run_extract(&ctx, &fx.urls, args(), &mut buf).unwrap();
+    run_extract(&ctx, &fx.history(&ctx), args(), &mut buf).unwrap();
     let entries: Vec<_> = std::fs::read_dir(&out_dir)
         .unwrap()
         .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
@@ -368,7 +364,7 @@ fn extract_writes_per_package_dirs_idempotently() {
         .is_file());
 
     buf.clear();
-    run_extract(&ctx, &fx.urls, args(), &mut buf).unwrap();
+    run_extract(&ctx, &fx.history(&ctx), args(), &mut buf).unwrap();
     let s = String::from_utf8(buf).unwrap();
     assert!(s.contains("0 extracted, 2 already present"), "{s}");
 }
@@ -419,7 +415,7 @@ fn extract_propagates_worker_error() {
     let mut buf = Vec::new();
     let err = run_extract(
         &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         ExtractArgs {
             build_version: "18.6.11819.183".into(),
             out: out_dir,

--- a/src/cli/tests/windows_sdk.rs
+++ b/src/cli/tests/windows_sdk.rs
@@ -70,7 +70,7 @@ fn versions_lists_distinct_across_series_sorted_desc() {
     );
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
-    run_versions(&ctx, &fx.urls, VersionsArgs {}, &mut out).unwrap();
+    run_versions(&fx.history(&ctx), VersionsArgs {}, &mut out).unwrap();
     let s = String::from_utf8(out).unwrap();
     assert!(s.contains("Windows SDK versions"), "{s}");
     assert!(s.contains("26100"), "{s}");
@@ -121,8 +121,7 @@ fn packages_groups_default_and_extras() {
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
     run_packages(
-        &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         PackagesArgs {
             sdk_version: "26100".into(),
         },
@@ -165,8 +164,7 @@ fn packages_errors_on_unknown_sdk_version() {
     let ctx = test_ctx(&tmp);
     let mut out = Vec::new();
     let err = run_packages(
-        &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         PackagesArgs {
             sdk_version: "99999".into(),
         },
@@ -207,7 +205,7 @@ fn extract_errors_on_unknown_sdk_version() {
     let mut buf = Vec::new();
     let err = run_extract(
         &ctx,
-        &fx.urls,
+        &fx.history(&ctx),
         ExtractArgs {
             sdk_version: "99999".into(),
             out: out_dir,

--- a/src/cli/windows_sdk.rs
+++ b/src/cli/windows_sdk.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use crate::cli::resolve_config_path;
 use crate::extract;
 use crate::fs_util;
-use crate::providers::vs_manifest::{self, MirrorUrls};
+use crate::providers::vs_manifest::{self, ManifestHistory};
 use crate::providers::windows_sdk;
 use crate::providers::InstallCtx;
 
@@ -56,11 +56,11 @@ pub fn run(
     args: WindowsSdkArgs,
 ) -> Result<()> {
     let ctx = build_ctx(config, cache_dir_override)?;
-    let urls = MirrorUrls::default();
+    let history = ManifestHistory::open(&vs_manifest::default_remote(), ctx.cache())?;
     match args.verb {
-        WindowsSdkVerb::Versions(a) => run_versions(&ctx, &urls, a, &mut std::io::stdout()),
-        WindowsSdkVerb::Packages(a) => run_packages(&ctx, &urls, a, &mut std::io::stdout()),
-        WindowsSdkVerb::Extract(a) => run_extract(&ctx, &urls, a, &mut std::io::stdout()),
+        WindowsSdkVerb::Versions(a) => run_versions(&history, a, &mut std::io::stdout()),
+        WindowsSdkVerb::Packages(a) => run_packages(&history, a, &mut std::io::stdout()),
+        WindowsSdkVerb::Extract(a) => run_extract(&ctx, &history, a, &mut std::io::stdout()),
     }
 }
 
@@ -83,12 +83,11 @@ fn build_ctx(
 // ---- versions --------------------------------------------------------------
 
 fn run_versions(
-    ctx: &InstallCtx,
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     _args: VersionsArgs,
     out: &mut dyn std::io::Write,
 ) -> Result<()> {
-    let versions = windows_sdk::discover_sdk_versions(urls, ctx)?;
+    let versions = windows_sdk::discover_sdk_versions(history)?;
     if versions.is_empty() {
         writeln!(out, "(no Windows SDK versions discovered)")?;
         return Ok(());
@@ -103,12 +102,11 @@ fn run_versions(
 // ---- packages --------------------------------------------------------------
 
 fn run_packages(
-    ctx: &InstallCtx,
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     args: PackagesArgs,
     out: &mut dyn std::io::Write,
 ) -> Result<()> {
-    let resolved = windows_sdk::resolve_sdk_version(urls, &args.sdk_version, ctx)?;
+    let resolved = windows_sdk::resolve_sdk_version(history, &args.sdk_version)?;
     let msis = windows_sdk::enumerate_msis(&resolved.manifest, &resolved.sdk_pkg_id)?;
 
     let mut defaults: Vec<&String> = Vec::new();
@@ -146,11 +144,11 @@ fn run_packages(
 
 fn run_extract(
     ctx: &InstallCtx,
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     args: ExtractArgs,
     out: &mut dyn std::io::Write,
 ) -> Result<()> {
-    let resolved = windows_sdk::resolve_sdk_version(urls, &args.sdk_version, ctx)?;
+    let resolved = windows_sdk::resolve_sdk_version(history, &args.sdk_version)?;
     let component = manifest_lookup(&resolved.manifest, &resolved.sdk_pkg_id)
         .ok_or_else(|| anyhow!("SDK component {} not in manifest", resolved.sdk_pkg_id))?;
     let dep_ids: Vec<String> = component.dependencies.keys().cloned().collect();

--- a/src/download.rs
+++ b/src/download.rs
@@ -5,8 +5,28 @@ use anyhow::{Context, Result, anyhow, bail};
 use sha2::{Digest, Sha256};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
 use url::Url;
+
+/// Shared HTTP agent. Verifies server certificates against the OS trust store
+/// (via rustls-platform-verifier) rather than ureq's compiled-in webpki-roots,
+/// so natron works behind TLS-inspecting proxies and with enterprise/custom
+/// CAs installed system-wide.
+pub fn agent() -> &'static ureq::Agent {
+    static AGENT: OnceLock<ureq::Agent> = OnceLock::new();
+    AGENT.get_or_init(|| {
+        use ureq::tls::{RootCerts, TlsConfig};
+        ureq::Agent::config_builder()
+            .tls_config(
+                TlsConfig::builder()
+                    .root_certs(RootCerts::PlatformVerifier)
+                    .build(),
+            )
+            .build()
+            .new_agent()
+    })
+}
 
 /// Fetch `url` into the `cache` directory and return the absolute path of the
 /// cached file. If `expected_sha256` is provided, the download stream is
@@ -237,7 +257,7 @@ fn stream_once(
     bytes_received: &mut u64,
     verify_sha: bool,
 ) -> std::result::Result<(), StreamErr> {
-    let mut req = ureq::get(url);
+    let mut req = agent().get(url);
     if *bytes_received > 0 {
         req = req.header("Range", format!("bytes={}-", *bytes_received));
     }

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -11,11 +11,13 @@
 //!   - `archive` — explicit archive type; inferred from `asset` extension if omitted.
 //!   - `strip_prefix` — top-level directory to strip during extraction.
 //!
-//! Tests construct `GithubProvider::with_api_base("file:///path/to/fixtures")`
-//! to redirect the release-info HTTP call at a local fixture file.
+//! Release assets have a stable public URL
+//! (`{download_base}/{repo}/releases/download/{tag}/{asset}`), so we build it
+//! directly instead of querying the rate-limited releases API. Tests construct
+//! `GithubProvider::with_download_base("file:///path/to/fixtures")` to redirect
+//! the asset download at a local fixture tree.
 
 use anyhow::{Context, Result, anyhow};
-use serde::Deserialize;
 
 use super::{InstallCtx, Installed, Provider};
 use crate::cache::sanitize_fingerprint;
@@ -24,25 +26,26 @@ use crate::extract;
 
 pub const ID: &str = "github";
 
-/// Default GitHub API base URL.
-pub const DEFAULT_API_BASE: &str = "https://api.github.com";
+/// Default base for release-asset downloads. Real assets live under
+/// `https://github.com/{repo}/releases/download/...`.
+pub const DEFAULT_DOWNLOAD_BASE: &str = "https://github.com";
 
 pub struct GithubProvider {
-    api_base: String,
+    download_base: String,
 }
 
 impl GithubProvider {
     pub fn new() -> Self {
         Self {
-            api_base: DEFAULT_API_BASE.to_string(),
+            download_base: DEFAULT_DOWNLOAD_BASE.to_string(),
         }
     }
 
-    /// Override the API base URL (used by tests pointing at fixture
+    /// Override the download base (used by tests pointing at fixture
     /// directories served via `file://`).
-    pub fn with_api_base(api_base: impl Into<String>) -> Self {
+    pub fn with_download_base(download_base: impl Into<String>) -> Self {
         Self {
-            api_base: api_base.into(),
+            download_base: download_base.into(),
         }
     }
 }
@@ -86,36 +89,18 @@ impl Provider for GithubProvider {
             });
         }
 
-        // Fetch the release JSON from {api_base}/repos/{repo}/releases/tags/{tag}.
-        let release_url = format!(
-            "{}/repos/{}/releases/tags/{}",
-            self.api_base.trim_end_matches('/'),
+        // GitHub release assets have a stable, predictable download URL; build
+        // it directly rather than querying the (rate-limited) releases API.
+        let asset_url = format!(
+            "{}/{}/releases/download/{}/{}",
+            self.download_base.trim_end_matches('/'),
             repo,
-            tag
+            tag,
+            asset,
         );
-        let release_path = ctx
-            .download(&release_url, None)
-            .with_context(|| format!("fetching GitHub release info from {release_url}"))?;
-        let release_text = std::fs::read_to_string(&release_path)
-            .with_context(|| format!("reading {}", release_path.display()))?;
-        let release: ReleaseResponse = serde_json::from_str(&release_text)
-            .with_context(|| format!("parsing release JSON from {}", release_path.display()))?;
-
-        let asset_url = release
-            .assets
-            .into_iter()
-            .find(|a| a.name == asset)
-            .ok_or_else(|| {
-                anyhow!(
-                    "asset '{asset}' not found in release {}/{tag} (api_base={})",
-                    repo,
-                    self.api_base
-                )
-            })?
-            .browser_download_url;
-
-        // Download the asset itself, sha-verifying if pinned.
-        let archive_path = ctx.download(&asset_url, sha256)?;
+        let archive_path = ctx
+            .download(&asset_url, sha256)
+            .with_context(|| format!("downloading {asset} from {asset_url}"))?;
 
         // Extract into the staging dir.
         let staging_raw = ctx.staging_dir()?;
@@ -173,20 +158,6 @@ fn display(repo: &str, tag: &str, version: Option<&str>, asset: &str) -> String 
     format!("github {repo} {label} ({stem})")
 }
 
-#[derive(Debug, Deserialize)]
-struct ReleaseResponse {
-    #[serde(default)]
-    #[allow(dead_code)] // we don't currently use tag_name; keep so JSON shape matches
-    tag_name: Option<String>,
-    #[serde(default)]
-    assets: Vec<AssetEntry>,
-}
-
-#[derive(Debug, Deserialize)]
-struct AssetEntry {
-    name: String,
-    browser_download_url: String,
-}
 #[cfg(test)]
 #[path = "tests/github.rs"]
 mod tests;

--- a/src/providers/msvc.rs
+++ b/src/providers/msvc.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeSet;
 use std::path::Path;
 use xxhash_rust::xxh3::xxh3_64;
 
-use super::vs_manifest::{self, MirrorUrls, Package, VsManifest, VsVersion};
+use super::vs_manifest::{self, ManifestHistory, Package, VsManifest, VsVersion};
 use super::{InstallCtx, Installed, Provider};
 use crate::cache::sanitize_fingerprint;
 use crate::extract;
@@ -106,18 +106,20 @@ struct PackageRequest {
 // ---- provider --------------------------------------------------------------
 
 pub struct MsvcProvider {
-    urls: MirrorUrls,
+    remote: String,
 }
 
 impl MsvcProvider {
     pub fn new() -> Self {
         Self {
-            urls: MirrorUrls::default(),
+            remote: vs_manifest::default_remote(),
         }
     }
 
-    pub fn with_urls(urls: MirrorUrls) -> Self {
-        Self { urls }
+    pub fn with_remote(remote: impl Into<String>) -> Self {
+        Self {
+            remote: remote.into(),
+        }
     }
 }
 
@@ -145,8 +147,9 @@ impl Provider for MsvcProvider {
             });
         }
 
-        let entry = vs_manifest::resolve_build_version(&self.urls, &opts.build_version, ctx)?;
-        let manifest = vs_manifest::fetch_manifest_at(&self.urls.raw_base, &entry.commit.sha, ctx)?;
+        let history = ManifestHistory::open(&self.remote, ctx.cache())?;
+        let entry = history.resolve_build_version(&opts.build_version)?;
+        let manifest = history.manifest(&entry.commit.sha)?;
         let compiler = find_primary_compiler(&manifest, entry.vs)
             .with_context(|| format!("locating primary compiler for build {}", opts.build_version))?;
         let family = family_prefix(&compiler.id)?;

--- a/src/providers/tests/github.rs
+++ b/src/providers/tests/github.rs
@@ -1,4 +1,4 @@
-//! Tests for `src/providers\github.rs` (split out so the production
+//! Tests for `src/providers/github.rs` (split out so the production
 //! file shows only the implementation).
 
 use super::*;
@@ -20,27 +20,25 @@ fn build_zip(path: &Path, entries: &[(&str, &[u8])]) {
     zw.finish().unwrap();
 }
 
-/// Write a fake GitHub release-info JSON. The asset's
-/// browser_download_url points at the local archive file.
-fn write_release_json(
-    api_base_dir: &Path,
-    repo: &str,
-    tag: &str,
-    asset_name: &str,
-    archive_path: &Path,
-) {
-    let path = api_base_dir
-        .join("repos")
+/// Place `archive` where the provider expects a release asset:
+/// `<base_dir>/{repo}/releases/download/{tag}/{asset}`.
+fn place_asset(base_dir: &Path, repo: &str, tag: &str, asset: &str, archive: &Path) {
+    let dst = base_dir
         .join(repo)
         .join("releases")
-        .join("tags")
-        .join(tag);
-    fs::create_dir_all(path.parent().unwrap()).unwrap();
-    let asset_url = url::Url::from_file_path(archive_path).unwrap().to_string();
-    let json = format!(
-        r#"{{"tag_name":"{tag}","assets":[{{"name":"{asset_name}","browser_download_url":"{asset_url}"}}]}}"#
-    );
-    fs::write(&path, json).unwrap();
+        .join("download")
+        .join(tag)
+        .join(asset);
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    fs::copy(archive, &dst).unwrap();
+}
+
+fn download_base(dir: &Path) -> String {
+    url::Url::from_directory_path(dir)
+        .unwrap()
+        .to_string()
+        .trim_end_matches('/')
+        .to_string()
 }
 
 #[test]
@@ -51,14 +49,10 @@ fn github_provider_id() {
 #[test]
 fn github_provider_resolves_release_and_extracts() {
     let tmp = TempDir::new().unwrap();
-    let api = tmp.path().join("api");
+    let base = tmp.path().join("dl");
     let archive = tmp.path().join("clang.zip");
     build_zip(&archive, &[("bin/clang.exe", b"BIN"), ("LICENSE", b"LIC")]);
-    write_release_json(&api, "llvm/llvm-project", "llvmorg-21.1.6", "clang.zip", &archive);
-
-    let api_base = url::Url::from_directory_path(&api).unwrap().to_string();
-    // Trim trailing slash because we add one when constructing URLs.
-    let api_base = api_base.trim_end_matches('/').to_string();
+    place_asset(&base, "llvm/llvm-project", "llvmorg-21.1.6", "clang.zip", &archive);
 
     let cache = Cache::at(tmp.path().join("c"));
     cache.ensure_layout().unwrap();
@@ -69,7 +63,7 @@ fn github_provider_resolves_release_and_extracts() {
     opts.insert("tag".into(), toml::Value::String("llvmorg-21.1.6".into()));
     opts.insert("asset".into(), toml::Value::String("clang.zip".into()));
 
-    let provider = GithubProvider::with_api_base(api_base);
+    let provider = GithubProvider::with_download_base(download_base(&base));
     let installed = provider.install(&opts, &mut ctx).unwrap();
     assert!(installed.freshly_extracted);
     assert!(installed.fingerprint.contains("llvmorg-21.1.6"));
@@ -81,13 +75,11 @@ fn github_provider_resolves_release_and_extracts() {
 #[test]
 fn github_provider_missing_asset_errors() {
     let tmp = TempDir::new().unwrap();
-    let api = tmp.path().join("api");
+    let base = tmp.path().join("dl");
+    // Place a different asset; the one we request is absent.
     let archive = tmp.path().join("real.zip");
     build_zip(&archive, &[("f", b"F")]);
-    write_release_json(&api, "owner/repo", "v1", "real.zip", &archive);
-
-    let api_base = url::Url::from_directory_path(&api).unwrap().to_string();
-    let api_base = api_base.trim_end_matches('/').to_string();
+    place_asset(&base, "owner/repo", "v1", "real.zip", &archive);
 
     let cache = Cache::at(tmp.path().join("c"));
     cache.ensure_layout().unwrap();
@@ -98,9 +90,12 @@ fn github_provider_missing_asset_errors() {
     opts.insert("tag".into(), toml::Value::String("v1".into()));
     opts.insert("asset".into(), toml::Value::String("does-not-exist.zip".into()));
 
-    let provider = GithubProvider::with_api_base(api_base);
+    let provider = GithubProvider::with_download_base(download_base(&base));
     let err = provider.install(&opts, &mut ctx).unwrap_err();
-    assert!(err.to_string().contains("not found"));
+    assert!(
+        format!("{err:#}").contains("does-not-exist.zip"),
+        "got: {err:#}"
+    );
 }
 
 #[test]
@@ -137,13 +132,6 @@ fn github_archive_kind_inference() {
 #[test]
 fn github_cache_hit_short_circuits() {
     let tmp = TempDir::new().unwrap();
-    let api = tmp.path().join("api");
-    let archive = tmp.path().join("a.zip");
-    build_zip(&archive, &[("f", b"F")]);
-    write_release_json(&api, "x/y", "v", "a.zip", &archive);
-    let api_base = url::Url::from_directory_path(&api).unwrap().to_string();
-    let api_base = api_base.trim_end_matches('/').to_string();
-
     let cache = Cache::at(tmp.path().join("c"));
     cache.ensure_layout().unwrap();
     let mut opts = toml::Table::new();
@@ -165,7 +153,8 @@ fn github_cache_hit_short_circuits() {
     md.write(&cache.install_metadata_path(&sanitized)).unwrap();
 
     let mut ctx = InstallCtx::new(cache);
-    let provider = GithubProvider::with_api_base(api_base);
+    // Download base points nowhere real — a cache hit must not touch it.
+    let provider = GithubProvider::with_download_base("file:///never/exists");
     let installed = provider.install(&opts, &mut ctx).unwrap();
     assert!(!installed.freshly_extracted, "should have hit cache");
     // No staging dir should have been allocated.

--- a/src/providers/tests/msvc.rs
+++ b/src/providers/tests/msvc.rs
@@ -272,7 +272,7 @@ fn install_default_extracts_expected_files() {
 
     let ctx = test_ctx(&tmp);
     let mut ctx = ctx; // mut for install
-    let provider = MsvcProvider::with_urls(fx.urls.clone());
+    let provider = MsvcProvider::with_remote(fx.remote.clone());
     let mut opts = toml::Table::new();
     opts.insert(
         "build_version".into(),
@@ -326,10 +326,7 @@ fn install_cache_hit_skips_fetch() {
     md.write(&cache.install_metadata_path(&fp)).unwrap();
 
     let mut ctx = InstallCtx::new(cache);
-    let provider = MsvcProvider::with_urls(MirrorUrls {
-        raw_base: "file:///never/exists".into(),
-        commits_base: "file:///never/commits-{branch}.json".into(),
-    });
+    let provider = MsvcProvider::with_remote("file:///never/exists");
     let installed = provider.install(&opts, &mut ctx).unwrap();
     assert!(!installed.freshly_extracted);
     assert!(ctx.staging_root().is_none());

--- a/src/providers/tests/vs_manifest.rs
+++ b/src/providers/tests/vs_manifest.rs
@@ -300,3 +300,50 @@ fn commits_filtered_to_channel_json_touching() {
     assert_eq!(entries.len(), 1, "only channel.json commits should appear");
     assert_eq!(entries[0].info.build_version, "18.6.0.0");
 }
+
+#[test]
+fn open_refetches_new_upstream_commits_on_existing_clone() {
+    // Regression guard for the `--mirror` requirement. A second open() against
+    // an already-cloned cache must `git fetch` newly shipped upstream commits,
+    // not serve the snapshot set frozen at first-clone time. A plain
+    // `git clone --bare` configures no fetch refspec, so its refresh fetch is a
+    // no-op for branch refs and this test would see only the original build.
+    let tmp = TempDir::new().unwrap();
+    let fx = MirrorFixture::build(
+        tmp.path(),
+        &[(
+            VsVersion::Vs2026,
+            &[FxSnapshot {
+                sha: "first",
+                date: "2026-05-01T00:00:00Z",
+                build_version: "18.6.0.0",
+                display_version: "18.6",
+                product_line_version: "18",
+                manifest_packages_json: String::new(),
+            }],
+        )],
+    );
+    let ctx = test_ctx(&tmp);
+
+    // First open clones the mirror; one build visible.
+    let first = fx.history(&ctx).index(&[VsVersion::Vs2026]).unwrap();
+    assert_eq!(first.len(), 1);
+
+    // Upstream ships a newer release on release-18.
+    std::fs::write(
+        fx.root.join("channel.json"),
+        channel_json("18.7.0.0", "18.7", "18"),
+    )
+    .unwrap();
+    git(&fx.root, &["add", "channel.json"]);
+    git_commit(&fx.root, "second", "2026-06-01T00:00:00Z");
+
+    // Second open reuses the same cache, so it must fetch and now see both.
+    let second = fx.history(&ctx).index(&[VsVersion::Vs2026]).unwrap();
+    assert_eq!(
+        second.len(),
+        2,
+        "open() must refetch new upstream commits on an existing clone"
+    );
+    assert_eq!(second[0].info.build_version, "18.7.0.0");
+}

--- a/src/providers/tests/vs_manifest.rs
+++ b/src/providers/tests/vs_manifest.rs
@@ -6,11 +6,13 @@ use crate::cache::Cache;
 use crate::providers::InstallCtx;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use tempfile::TempDir;
 
 // ---- fixture builder -------------------------------------------------------
 
-/// One synthetic Microsoft snapshot.
+/// One synthetic Microsoft snapshot. `sha` is a human label used as the
+/// commit message; git assigns the real commit hash.
 pub(crate) struct FxSnapshot {
     pub sha: &'static str,
     pub date: &'static str,
@@ -20,69 +22,82 @@ pub(crate) struct FxSnapshot {
     pub manifest_packages_json: String,
 }
 
-/// On-disk mirror layout that mimics the GitHub commits API + per-commit
-/// `channel.json` / `manifest.json`. Returns URL bases the providers/CLI
-/// can be pointed at.
+/// A throwaway git repo mirroring the manifest-history layout: one
+/// `release-{channel}` branch per VS series, one commit per snapshot carrying
+/// that snapshot's `channel.json` + `manifest.json`. Returns a `remote` the
+/// providers/CLI clone via `file://`.
 pub(crate) struct MirrorFixture {
-    pub urls: MirrorUrls,
-    #[allow(dead_code)]
+    pub remote: String,
     pub root: PathBuf,
 }
 
 impl MirrorFixture {
     pub fn build(tmp: &Path, per_branch: &[(VsVersion, &[FxSnapshot])]) -> Self {
-        let root = tmp.join("mirror");
+        let root = tmp.join("mirror-src");
         std::fs::create_dir_all(&root).unwrap();
-
-        let raw_base = file_url(&root);
-        let commits_base = format!("{}/commits-{{branch}}.json", file_url(&root));
-
+        git(&root, &["init", "--quiet"]);
         for (vs, snapshots) in per_branch {
-            let commits_json: String = snapshots
-                .iter()
-                .map(|s| {
-                    format!(
-                        r#"{{"sha":"{sha}","commit":{{"author":{{"date":"{date}"}}}}}}"#,
-                        sha = s.sha,
-                        date = s.date,
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(",");
-            std::fs::write(
-                root.join(format!("commits-release-{}.json", vs.channel())),
-                format!("[{commits_json}]"),
-            )
-            .unwrap();
-
+            let branch = format!("release-{}", vs.channel());
+            git(&root, &["checkout", "--quiet", "--orphan", branch.as_str()]);
             for s in *snapshots {
-                let dir = root.join(s.sha);
-                std::fs::create_dir_all(&dir).unwrap();
                 std::fs::write(
-                    dir.join("channel.json"),
-                    channel_json(
-                        s.build_version,
-                        s.display_version,
-                        s.product_line_version,
-                    ),
+                    root.join("channel.json"),
+                    channel_json(s.build_version, s.display_version, s.product_line_version),
                 )
                 .unwrap();
                 std::fs::write(
-                    dir.join("manifest.json"),
+                    root.join("manifest.json"),
                     format!(r#"{{"packages":[{}]}}"#, s.manifest_packages_json),
                 )
                 .unwrap();
+                git(&root, &["add", "channel.json", "manifest.json"]);
+                git_commit(&root, s.sha, s.date);
             }
         }
-
         MirrorFixture {
-            urls: MirrorUrls {
-                raw_base,
-                commits_base,
-            },
+            remote: file_url(&root),
             root,
         }
     }
+
+    /// Open a `ManifestHistory` against this fixture's clone.
+    pub fn history(&self, ctx: &InstallCtx) -> ManifestHistory {
+        ManifestHistory::open(&self.remote, ctx.cache()).expect("open mirror")
+    }
+}
+
+/// Run a git subcommand in `repo`, asserting success.
+fn git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .status()
+        .expect("spawn git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// Commit the staged tree with a fixed identity, signing disabled, and the
+/// author/committer date set to `date` so `git log` ordering is deterministic.
+fn git_commit(repo: &Path, message: &str, date: &str) {
+    let status = Command::new("git")
+        .current_dir(repo)
+        .env("GIT_AUTHOR_DATE", date)
+        .env("GIT_COMMITTER_DATE", date)
+        .args([
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "-m",
+            message,
+        ])
+        .status()
+        .expect("spawn git commit");
+    assert!(status.success(), "git commit failed");
 }
 
 pub(crate) fn channel_json(
@@ -193,7 +208,7 @@ fn build_index_sorts_commits_descending_by_date() {
         )],
     );
     let ctx = test_ctx(&tmp);
-    let entries = build_index(&fx.urls, &[VsVersion::Vs2026], &ctx).unwrap();
+    let entries = fx.history(&ctx).index(&[VsVersion::Vs2026]).unwrap();
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].info.build_version, "18.6.0.0");
     assert_eq!(entries[1].info.build_version, "18.0.0.0");
@@ -217,8 +232,8 @@ fn resolve_build_version_finds_exact_match() {
         )],
     );
     let ctx = test_ctx(&tmp);
-    let entry = resolve_build_version(&fx.urls, "18.6.11819.183", &ctx).unwrap();
-    assert_eq!(entry.commit.sha, "sha_a");
+    let entry = fx.history(&ctx).resolve_build_version("18.6.11819.183").unwrap();
+    assert_eq!(entry.info.build_version, "18.6.11819.183");
     assert_eq!(entry.vs, VsVersion::Vs2026);
 }
 
@@ -240,7 +255,7 @@ fn resolve_build_version_lists_alternatives_on_miss() {
         )],
     );
     let ctx = test_ctx(&tmp);
-    let err = resolve_build_version(&fx.urls, "18.99.99.99", &ctx).unwrap_err();
+    let err = fx.history(&ctx).resolve_build_version("18.99.99.99").unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("18.99.99.99"), "got: {msg}");
     assert!(msg.contains("18.6.11819.183"), "got: {msg}");
@@ -251,27 +266,37 @@ fn resolve_build_version_rejects_unknown_major() {
     let tmp = TempDir::new().unwrap();
     let fx = MirrorFixture::build(tmp.path(), &[]);
     let ctx = test_ctx(&tmp);
-    let err = resolve_build_version(&fx.urls, "15.0.0.0", &ctx).unwrap_err();
+    let err = fx.history(&ctx).resolve_build_version("15.0.0.0").unwrap_err();
     assert!(err.to_string().contains("15"), "got: {err}");
 }
 
 #[test]
-fn default_commits_base_includes_path_filter() {
-    // Regression guard: `?path=channel.json` filters out the mirror's
-    // initial CI-setup commits which would otherwise show as 404 warnings
-    // for users running `msvc versions`. Removing the filter is a regression.
-    let url = default_commits_base();
-    assert!(
-        url.contains("path=channel.json"),
-        "default_commits_base() lost the path filter: {url}"
-    );
-}
-
-#[test]
-fn parse_json_evicts_cache_on_corruption() {
+fn commits_filtered_to_channel_json_touching() {
+    // Regression guard: enumeration must skip the mirror's initial CI-setup
+    // commits that lack channel.json. We commit one such bare commit, then a
+    // real snapshot; only the snapshot should appear in the index.
     let tmp = TempDir::new().unwrap();
-    let bad = tmp.path().join("bad.json");
-    std::fs::write(&bad, "not json").unwrap();
-    let _: Result<serde_json::Value> = parse_json_or_evict(&bad, "test");
-    assert!(!bad.exists(), "corrupt file should have been evicted");
+    let fx = MirrorFixture::build(
+        tmp.path(),
+        &[(
+            VsVersion::Vs2026,
+            &[FxSnapshot {
+                sha: "real",
+                date: "2026-05-01T00:00:00Z",
+                build_version: "18.6.0.0",
+                display_version: "18.6",
+                product_line_version: "18",
+                manifest_packages_json: String::new(),
+            }],
+        )],
+    );
+    // Add a commit on release-18 that does NOT touch channel.json.
+    std::fs::write(fx.root.join("README.md"), b"ci setup").unwrap();
+    git(&fx.root, &["add", "README.md"]);
+    git_commit(&fx.root, "ci setup", "2026-05-02T00:00:00Z");
+
+    let ctx = test_ctx(&tmp);
+    let entries = fx.history(&ctx).index(&[VsVersion::Vs2026]).unwrap();
+    assert_eq!(entries.len(), 1, "only channel.json commits should appear");
+    assert_eq!(entries[0].info.build_version, "18.6.0.0");
 }

--- a/src/providers/tests/vs_manifest.rs
+++ b/src/providers/tests/vs_manifest.rs
@@ -217,24 +217,49 @@ fn build_index_sorts_commits_descending_by_date() {
 #[test]
 fn resolve_build_version_finds_exact_match() {
     let tmp = TempDir::new().unwrap();
+    // Two snapshots on the same series. Resolving must return the entry for
+    // the requested build, proven by a field that is NOT the match key
+    // (product_display_version comes from that commit's channel.json).
     let fx = MirrorFixture::build(
         tmp.path(),
         &[(
             VsVersion::Vs2026,
-            &[FxSnapshot {
-                sha: "sha_a",
-                date: "2026-05-01T00:00:00Z",
-                build_version: "18.6.11819.183",
-                display_version: "18.6.1",
-                product_line_version: "18",
-                manifest_packages_json: String::new(),
-            }],
+            &[
+                FxSnapshot {
+                    sha: "sha_old",
+                    date: "2026-04-01T00:00:00Z",
+                    build_version: "18.5.9000.0",
+                    display_version: "18.5",
+                    product_line_version: "18",
+                    manifest_packages_json: String::new(),
+                },
+                FxSnapshot {
+                    sha: "sha_a",
+                    date: "2026-05-01T00:00:00Z",
+                    build_version: "18.6.11819.183",
+                    display_version: "18.6.1",
+                    product_line_version: "18",
+                    manifest_packages_json: String::new(),
+                },
+            ],
         )],
     );
     let ctx = test_ctx(&tmp);
-    let entry = fx.history(&ctx).resolve_build_version("18.6.11819.183").unwrap();
+    let history = fx.history(&ctx);
+
+    let entry = history.resolve_build_version("18.6.11819.183").unwrap();
     assert_eq!(entry.info.build_version, "18.6.11819.183");
     assert_eq!(entry.vs, VsVersion::Vs2026);
+    // The load came from the matching commit, not the other snapshot.
+    assert_eq!(entry.info.product_display_version, "18.6.1");
+
+    // Resolving the other build returns its own distinct commit + metadata.
+    let other = history.resolve_build_version("18.5.9000.0").unwrap();
+    assert_eq!(other.info.product_display_version, "18.5");
+    assert_ne!(
+        entry.commit.sha, other.commit.sha,
+        "distinct builds must resolve to distinct commits"
+    );
 }
 
 #[test]
@@ -346,4 +371,52 @@ fn open_refetches_new_upstream_commits_on_existing_clone() {
         "open() must refetch new upstream commits on an existing clone"
     );
     assert_eq!(second[0].info.build_version, "18.7.0.0");
+}
+
+#[test]
+fn newest_returns_latest_valid_commit_skipping_unparseable() {
+    // Guards the newest()-only optimization: with several commits per branch,
+    // it must return the newest by date AND fall through a newest commit whose
+    // channel.json doesn't parse. A naive "first/oldest commit" or a
+    // "newest commit, no skip" implementation would fail this.
+    let tmp = TempDir::new().unwrap();
+    let fx = MirrorFixture::build(
+        tmp.path(),
+        &[(
+            VsVersion::Vs2026,
+            &[
+                FxSnapshot {
+                    sha: "old",
+                    date: "2026-01-01T00:00:00Z",
+                    build_version: "18.5.0.0",
+                    display_version: "18.5",
+                    product_line_version: "18",
+                    manifest_packages_json: String::new(),
+                },
+                FxSnapshot {
+                    sha: "newest-valid",
+                    date: "2026-05-01T00:00:00Z",
+                    build_version: "18.6.0.0",
+                    display_version: "18.6",
+                    product_line_version: "18",
+                    manifest_packages_json: String::new(),
+                },
+            ],
+        )],
+    );
+    // Newest commit by date carries a corrupt channel.json.
+    std::fs::write(fx.root.join("channel.json"), b"{ not valid json").unwrap();
+    git(&fx.root, &["add", "channel.json"]);
+    git_commit(&fx.root, "corrupt", "2026-06-01T00:00:00Z");
+
+    let ctx = test_ctx(&tmp);
+    let newest = fx
+        .history(&ctx)
+        .newest(VsVersion::Vs2026)
+        .unwrap()
+        .expect("a valid build exists");
+    assert_eq!(
+        newest.info.build_version, "18.6.0.0",
+        "newest() must skip the unparseable newest commit and return the next-newest valid one"
+    );
 }

--- a/src/providers/tests/windows_sdk.rs
+++ b/src/providers/tests/windows_sdk.rs
@@ -224,7 +224,7 @@ fn discover_sdk_versions_dedupes_across_series_sorted_desc() {
         ],
     );
     let ctx = test_ctx(&tmp);
-    let versions = discover_sdk_versions(&fx.urls, &ctx).unwrap();
+    let versions = discover_sdk_versions(&fx.history(&ctx)).unwrap();
     assert_eq!(versions, vec!["26100", "22621", "22000", "19041", "17763"]);
 }
 
@@ -256,8 +256,8 @@ fn resolve_finds_sdk_in_newest_snapshot_containing_it() {
     );
     let ctx = test_ctx(&tmp);
     // 22000 is only in vs2022; resolve should walk down to find it.
-    let resolved = resolve_sdk_version(&fx.urls, "22000", &ctx).unwrap();
-    assert_eq!(resolved.entry.commit.sha, "s17");
+    let resolved = resolve_sdk_version(&fx.history(&ctx), "22000").unwrap();
+    assert_eq!(resolved.entry.vs, VsVersion::Vs2022);
     assert!(resolved.sdk_pkg_id.ends_with(".22000"));
 }
 
@@ -277,7 +277,7 @@ fn resolve_errors_with_available_list_on_miss() {
         )],
     );
     let ctx = test_ctx(&tmp);
-    let err = resolve_sdk_version(&fx.urls, "99999", &ctx).unwrap_err();
+    let err = resolve_sdk_version(&fx.history(&ctx), "99999").unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("99999"), "got: {msg}");
     assert!(msg.contains("26100"), "got: {msg}");
@@ -320,10 +320,7 @@ fn install_cache_fast_path_skips_fetch() {
     md.write(&cache.install_metadata_path(&fp)).unwrap();
 
     let mut ctx = InstallCtx::new(cache);
-    let provider = WindowsSdkProvider::with_urls(MirrorUrls {
-        raw_base: "file:///never".into(),
-        commits_base: "file:///never/{branch}.json".into(),
-    });
+    let provider = WindowsSdkProvider::with_remote("file:///never");
     let mut topts = toml::Table::new();
     topts.insert("sdk_version".into(), toml::Value::String("26100".into()));
     let installed = provider.install(&topts, &mut ctx).unwrap();
@@ -468,7 +465,7 @@ fn install_errors_on_extras_zero_match() {
     );
 
     let mut ctx = test_ctx(&tmp);
-    let provider = WindowsSdkProvider::with_urls(fx.urls);
+    let provider = WindowsSdkProvider::with_remote(fx.remote);
     let mut opts = toml::Table::new();
     opts.insert("sdk_version".into(), toml::Value::String(sdk_v.into()));
     opts.insert(

--- a/src/providers/vs_manifest.rs
+++ b/src/providers/vs_manifest.rs
@@ -196,9 +196,24 @@ impl ManifestHistory {
         Ok(out)
     }
 
-    /// Newest build for one series, if any.
+    /// Newest build for one series, if any. Reads `channel.json` only for the
+    /// newest commit(s) — stopping at the first that parses — rather than the
+    /// whole branch like [`Self::index`], since callers (SDK discovery /
+    /// resolution) only need the latest snapshot per series.
     pub fn newest(&self, vs: VsVersion) -> Result<Option<BuildIndexEntry>> {
-        Ok(self.index(&[vs])?.into_iter().next())
+        let mut commits = self.commits_on_branch(vs)?;
+        commits.sort_by(|a, b| b.date.cmp(&a.date));
+        for commit in commits {
+            match self.channel_info_at(&commit.sha) {
+                Ok(info) => return Ok(Some(BuildIndexEntry { vs, info, commit })),
+                Err(err) => tracing::warn!(
+                    "skipping commit {} on {}: {err:#}",
+                    &commit.sha[..commit.sha.len().min(7)],
+                    vs.as_str(),
+                ),
+            }
+        }
+        Ok(None)
     }
 
     /// Resolve a buildVersion to its entry. Auto-detects the VS series from
@@ -341,9 +356,17 @@ fn clone_into(remote: &str, dest: &Path, meta_dir: &Path) -> Result<()> {
         let _ = fs_util::remove_dir_all_writable(&tmp);
         return Err(err).with_context(|| format!("cloning manifest mirror from {remote}"));
     }
-    if std::fs::rename(&tmp, dest).is_err() {
-        // A peer published the clone first; keep theirs, drop ours.
+    if let Err(err) = std::fs::rename(&tmp, dest) {
         let _ = fs_util::remove_dir_all_writable(&tmp);
+        // A peer publishing first is fine — `dest` now holds their clone, so
+        // drop ours and use theirs. Any other failure (ENOSPC, EACCES, …)
+        // left `dest` absent; surface it rather than returning a handle to a
+        // path that doesn't exist (which would only fail later as an opaque
+        // `git` error on the first query).
+        if !dest.is_dir() {
+            return Err(err)
+                .with_context(|| format!("publishing manifest mirror clone to {}", dest.display()));
+        }
     }
     Ok(())
 }

--- a/src/providers/vs_manifest.rs
+++ b/src/providers/vs_manifest.rs
@@ -438,7 +438,8 @@ pub fn http_get(url: &str) -> Result<String> {
         return std::fs::read_to_string(&p)
             .with_context(|| format!("reading file URL {}", p.display()));
     }
-    let resp = ureq::get(url)
+    let resp = crate::download::agent()
+        .get(url)
         .header("User-Agent", USER_AGENT)
         .header("Accept", "application/json")
         .call()

--- a/src/providers/vs_manifest.rs
+++ b/src/providers/vs_manifest.rs
@@ -318,16 +318,23 @@ fn git_in(dir: &Path, args: &[&str]) -> Result<Vec<u8>> {
     run_git(cmd)
 }
 
-/// Bare partial clone of `remote` into `dest` (a subdir of `meta_dir`). Clones
-/// into a unique temp dir under `meta_dir` then atomically renames it into
-/// place, so two concurrent natron runs can't corrupt a shared clone (same
-/// lock-free publish as the CAS).
+/// Mirror partial clone of `remote` into `dest` (a subdir of `meta_dir`).
+/// Clones into a unique temp dir under `meta_dir` then atomically renames it
+/// into place, so two concurrent natron runs can't corrupt a shared clone
+/// (same lock-free publish as the CAS).
+///
+/// `--mirror` (not plain `--bare`): a bare clone configures no
+/// `remote.origin.fetch` refspec, so the periodic `git fetch` in
+/// [`ManifestHistory::open`] would update only FETCH_HEAD and never advance
+/// `release-*`, freezing the snapshot set at first-clone time. `--mirror`
+/// sets `+refs/*:refs/*`, so fetch keeps the local branches current and newly
+/// shipped releases actually appear.
 fn clone_into(remote: &str, dest: &Path, meta_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(meta_dir)
         .with_context(|| format!("creating {}", meta_dir.display()))?;
     let tmp = meta_dir.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
     let mut cmd = Command::new("git");
-    cmd.args(["clone", "--bare", "--filter=blob:limit=1m"])
+    cmd.args(["clone", "--mirror", "--filter=blob:limit=1m"])
         .arg(remote)
         .arg(&tmp);
     if let Err(err) = run_git(cmd) {

--- a/src/providers/vs_manifest.rs
+++ b/src/providers/vs_manifest.rs
@@ -6,21 +6,27 @@
 //! `channel.json` header (~130 KB). The full package list lives in the
 //! per-commit `manifest.json` (~15-25 MB).
 //!
+//! We read the mirror through a local **partial clone** rather than the
+//! GitHub REST API (whose anonymous rate limit is 60 req/hr per IP). A bare
+//! `git clone --filter=blob:limit=1m` pulls every commit + tree + the small
+//! `channel.json` blobs, deferring the big `manifest.json` blobs to on-demand
+//! `git cat-file` (the promisor remote fetches them lazily). `git` is a hard
+//! requirement; there is no API fallback. See [`ManifestHistory`].
+//!
 //! Pinning a `buildVersion` resolves to one commit_sha → one immutable
 //! manifest → one fixed set of CDN payload URLs. That's the only string
 //! that guarantees a reproducible install.
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
-use std::path::Path;
-use std::sync::Mutex;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use super::InstallCtx;
-use crate::download;
+use crate::cache::Cache;
+use crate::fs_util;
 
 const MIRROR_OWNER: &str = "roblabla";
 const MIRROR_REPO: &str = "msvc-manifest-history";
-const USER_AGENT: &str = concat!("natron/", env!("CARGO_PKG_VERSION"));
 
 // ---- types -----------------------------------------------------------------
 
@@ -132,286 +138,207 @@ pub struct Payload {
     pub file_name: Option<String>,
 }
 
-// ---- URL builders ----------------------------------------------------------
+// ---- manifest history (local partial clone) --------------------------------
 
-/// raw.githubusercontent.com URL pattern. The mirror parameter exists for
-/// test fixtures (`file://` URLs); production uses [`default_raw_base`].
-pub fn raw_url(base: &str, sha_or_branch: &str, filename: &str) -> String {
-    format!("{base}/{sha_or_branch}/{filename}")
+/// Default git remote for the manifest-history mirror.
+pub fn default_remote() -> String {
+    format!("https://github.com/{MIRROR_OWNER}/{MIRROR_REPO}")
 }
 
-pub fn default_raw_base() -> String {
-    format!("https://raw.githubusercontent.com/{MIRROR_OWNER}/{MIRROR_REPO}")
+/// A local bare partial clone of `roblabla/msvc-manifest-history`, opened for
+/// reading. [`ManifestHistory::open`] clones (or `git fetch`es) once; the
+/// query methods are then pure-local `git log` / `git cat-file`.
+///
+/// NOT general purpose: the `release-{channel}` branch layout and the
+/// `channel.json` / `manifest.json` filenames are specific to that mirror.
+pub struct ManifestHistory {
+    git_dir: PathBuf,
 }
 
-/// GitHub commits API for one release branch. Test fixtures override the
-/// base to point at a local `commits.json` file via `{branch}`.
-pub fn commits_url(base: &str, vs: VsVersion, page: u32) -> String {
-    base.replace("{branch}", &format!("release-{}", vs.channel()))
-        .replace("{page}", &page.to_string())
-}
-
-pub fn default_commits_base() -> String {
-    // `?path=channel.json` filters to commits that actually touched the file.
-    // Without it we'd also enumerate the mirror's initial CI-setup commits
-    // (which lack channel.json entirely) and pay a fetch + 404 per commit
-    // for nothing.
-    format!(
-        "https://api.github.com/repos/{MIRROR_OWNER}/{MIRROR_REPO}/commits?sha={{branch}}&path=channel.json&per_page=100&page={{page}}"
-    )
-}
-
-// ---- fetchers --------------------------------------------------------------
-
-/// Enumerate every commit on one release branch via the GitHub commits API.
-/// NOT cached — the response is tiny (~10 KB/page) and freshness matters
-/// when a new Microsoft release has just shipped.
-pub fn fetch_commits(commits_base: &str, vs: VsVersion) -> Result<Vec<CommitRef>> {
-    let mut out = Vec::new();
-    for page in 1u32.. {
-        let url = commits_url(commits_base, vs, page);
-        let body = http_get(&url)
-            .with_context(|| format!("fetching commits page {page} for {}", vs.as_str()))?;
-        let page_commits: Vec<GhCommit> = serde_json::from_str(&body)
-            .with_context(|| format!("parsing commits page {page} for {}", vs.as_str()))?;
-        if page_commits.is_empty() {
-            break;
+impl ManifestHistory {
+    /// Open the mirror under `<cache>/meta/msvc-manifest-history`, cloning it
+    /// (`--filter=blob:limit=1m`: commits + trees + the small `channel.json`
+    /// blobs, deferring the big `manifest.json` blobs) if absent, else
+    /// `git fetch`ing to pick up newly shipped releases. The fetch is
+    /// best-effort: a failure (e.g. a peer holds git's lock, or the network is
+    /// down) leaves the existing clone usable. Requires `git` on PATH.
+    pub fn open(remote: &str, cache: &Cache) -> Result<Self> {
+        let git_dir = cache.meta.join(MIRROR_REPO);
+        if git_dir.is_dir() {
+            let _ = git_in(&git_dir, &["fetch", "--quiet", "origin"]);
+        } else {
+            clone_into(remote, &git_dir, &cache.meta)?;
         }
-        let was_full = page_commits.len() == 100;
-        for c in page_commits {
-            out.push(CommitRef {
-                sha: c.sha,
-                date: c.commit.author.date,
-            });
-        }
-        if !was_full {
-            break;
-        }
+        Ok(Self { git_dir })
     }
-    Ok(out)
-}
 
-#[derive(Deserialize)]
-struct GhCommit {
-    sha: String,
-    commit: GhCommitInner,
-}
-
-#[derive(Deserialize)]
-struct GhCommitInner {
-    author: GhAuthor,
-}
-
-#[derive(Deserialize)]
-struct GhAuthor {
-    date: String,
-}
-
-/// Fetch + parse `channel.json` at a specific commit. Cached forever via
-/// the download layer (commit-sha-keyed URLs are immutable).
-pub fn fetch_channel_info(
-    raw_base: &str,
-    sha_or_branch: &str,
-    ctx: &InstallCtx,
-) -> Result<ChannelInfo> {
-    fetch_channel_info_with_cache(raw_base, sha_or_branch, &ctx.cache().downloads)
-}
-
-/// `Sync`-friendly variant of [`fetch_channel_info`] that takes a downloads
-/// directory directly. Used by [`build_index`] for parallel fan-out where
-/// the workers can't share `&InstallCtx` (its staging `RefCell` is not
-/// `Sync`).
-fn fetch_channel_info_with_cache(
-    raw_base: &str,
-    sha_or_branch: &str,
-    downloads: &Path,
-) -> Result<ChannelInfo> {
-    let url = raw_url(raw_base, sha_or_branch, "channel.json");
-    let path = download::fetch(&url, None, downloads)
-        .with_context(|| format!("fetching channel.json at {sha_or_branch}"))?;
-    #[derive(Deserialize)]
-    struct Wrapper {
-        info: ChannelInfo,
-    }
-    parse_json_or_evict::<Wrapper>(&path, "channel.json").map(|w| w.info)
-}
-
-/// Fetch + parse `manifest.json` at a specific commit. Cached forever.
-pub fn fetch_manifest_at(
-    raw_base: &str,
-    sha_or_branch: &str,
-    ctx: &InstallCtx,
-) -> Result<VsManifest> {
-    let url = raw_url(raw_base, sha_or_branch, "manifest.json");
-    let path = ctx
-        .download(&url, None)
-        .with_context(|| format!("fetching manifest.json at {sha_or_branch}"))?;
-    parse_json_or_evict(&path, "manifest.json")
-}
-
-/// Read a JSON file from disk and parse it. On parse failure, delete the
-/// cached file so the next call re-fetches (defensive against upstream
-/// briefly serving HTML or a truncated response that the download layer
-/// happened to cache).
-fn parse_json_or_evict<T: serde::de::DeserializeOwned>(
-    path: &std::path::Path,
-    label: &str,
-) -> Result<T> {
-    let text = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {label} at {}", path.display()))?;
-    match serde_json::from_str(&text) {
-        Ok(v) => Ok(v),
-        Err(err) => {
-            let _ = std::fs::remove_file(path);
-            Err(anyhow!(
-                "parsing {label} at {} (cached file deleted; re-run will refetch): {err}",
-                path.display(),
-            ))
-        }
-    }
-}
-
-// ---- index builder ---------------------------------------------------------
-
-/// Configuration for the fetchers — bundled so tests can swap both URL
-/// bases at once.
-#[derive(Debug, Clone)]
-pub struct MirrorUrls {
-    pub raw_base: String,
-    pub commits_base: String,
-}
-
-impl Default for MirrorUrls {
-    fn default() -> Self {
-        Self {
-            raw_base: default_raw_base(),
-            commits_base: default_commits_base(),
-        }
-    }
-}
-
-/// Maximum concurrent channel.json fetches during enumeration. Picked to
-/// saturate typical home internet without abusing GitHub's CDN.
-const PARALLEL_FETCH_LIMIT: usize = 16;
-
-/// Build the in-memory index across the requested VS series. For each
-/// series: list commits, then fetch every commit's channel.json in parallel
-/// (cached after first run). Sorted descending by commit date within each
-/// VS series.
-pub fn build_index(
-    urls: &MirrorUrls,
-    series: &[VsVersion],
-    ctx: &InstallCtx,
-) -> Result<Vec<BuildIndexEntry>> {
-    let downloads = ctx.cache().downloads.clone();
-    let mut out = Vec::new();
-    for vs in series {
-        let mut commits = fetch_commits(&urls.commits_base, *vs)?;
-        commits.sort_by(|a, b| b.date.cmp(&a.date));
-        out.extend(parallel_fetch_channel_infos(
-            &urls.raw_base,
-            &commits,
-            &downloads,
-            *vs,
-        ));
-    }
-    Ok(out)
-}
-
-/// Fan `fetch_channel_info_with_cache` out across a small worker pool.
-/// Results land in per-index slots so the input commit order (date-desc)
-/// is preserved without re-sorting. Fetch errors are logged and dropped.
-fn parallel_fetch_channel_infos(
-    raw_base: &str,
-    commits: &[CommitRef],
-    downloads: &Path,
-    vs: VsVersion,
-) -> Vec<BuildIndexEntry> {
-    if commits.is_empty() {
-        return Vec::new();
-    }
-    let queue: Mutex<Vec<usize>> = Mutex::new((0..commits.len()).rev().collect());
-    let results: Mutex<Vec<Option<ChannelInfo>>> = Mutex::new(vec![None; commits.len()]);
-
-    std::thread::scope(|s| {
-        for _ in 0..PARALLEL_FETCH_LIMIT.min(commits.len()) {
-            s.spawn(|| loop {
-                let idx = match queue.lock().unwrap().pop() {
-                    Some(i) => i,
-                    None => return,
-                };
-                let commit = &commits[idx];
-                match fetch_channel_info_with_cache(raw_base, &commit.sha, downloads) {
-                    Ok(info) => {
-                        results.lock().unwrap()[idx] = Some(info);
-                    }
+    /// All builds across the requested series, newest-first within each.
+    pub fn index(&self, series: &[VsVersion]) -> Result<Vec<BuildIndexEntry>> {
+        let mut out = Vec::new();
+        for vs in series {
+            let mut commits = self.commits_on_branch(*vs)?;
+            commits.sort_by(|a, b| b.date.cmp(&a.date));
+            for commit in commits {
+                match self.channel_info_at(&commit.sha) {
+                    Ok(info) => out.push(BuildIndexEntry {
+                        vs: *vs,
+                        info,
+                        commit,
+                    }),
                     Err(err) => tracing::warn!(
                         "skipping commit {} on {}: {err:#}",
                         &commit.sha[..commit.sha.len().min(7)],
                         vs.as_str(),
                     ),
                 }
-            });
+            }
         }
-    });
+        Ok(out)
+    }
 
-    results
-        .into_inner()
-        .unwrap()
-        .into_iter()
-        .enumerate()
-        .filter_map(|(idx, info)| {
-            info.map(|info| BuildIndexEntry {
-                vs,
-                info,
-                commit: commits[idx].clone(),
+    /// Newest build for one series, if any.
+    pub fn newest(&self, vs: VsVersion) -> Result<Option<BuildIndexEntry>> {
+        Ok(self.index(&[vs])?.into_iter().next())
+    }
+
+    /// Resolve a buildVersion to its entry. Auto-detects the VS series from
+    /// the version's major component. On miss, surfaces a few of the nearest
+    /// available buildVersions for context.
+    pub fn resolve_build_version(&self, build_version: &str) -> Result<BuildIndexEntry> {
+        let major = build_version_major(build_version)?;
+        let vs = VsVersion::from_channel(major)?;
+        let entries = self.index(&[vs])?;
+        if let Some(hit) = entries
+            .iter()
+            .find(|e| e.info.build_version == build_version)
+        {
+            return Ok(hit.clone());
+        }
+        let mut available: Vec<&str> = entries
+            .iter()
+            .map(|e| e.info.build_version.as_str())
+            .collect();
+        available.sort();
+        // Show 5 nearest (lex-closest) so the error fits on a terminal.
+        let suggestions: Vec<&&str> = available
+            .iter()
+            .filter(|v| v.starts_with(&format!("{major}.")))
+            .take(5)
+            .collect();
+        bail!(
+            "buildVersion '{build_version}' not found on {} (release-{major}); {} available; nearest: {}",
+            vs.as_str(),
+            available.len(),
+            if suggestions.is_empty() {
+                "(none)".to_string()
+            } else {
+                suggestions
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            },
+        )
+    }
+
+    /// Read + parse `manifest.json` at a commit. The blob is excluded from the
+    /// partial clone, so `git cat-file` lazily fetches it from the promisor
+    /// remote on first access (cached in the clone thereafter).
+    pub fn manifest(&self, sha: &str) -> Result<VsManifest> {
+        let bytes = self
+            .cat_blob(sha, "manifest.json")
+            .with_context(|| format!("reading manifest.json at {sha}"))?;
+        serde_json::from_slice(&bytes).with_context(|| format!("parsing manifest.json at {sha}"))
+    }
+
+    /// List the commits on one release branch that touched `channel.json`,
+    /// skipping the mirror's initial CI-setup commits that lack it. Unsorted;
+    /// callers sort by date.
+    fn commits_on_branch(&self, vs: VsVersion) -> Result<Vec<CommitRef>> {
+        let branch = format!("release-{}", vs.channel());
+        let stdout = git_in(
+            &self.git_dir,
+            &["log", "--format=%H %aI", branch.as_str(), "--", "channel.json"],
+        )
+        .with_context(|| format!("listing commits on {branch}"))?;
+        let text = String::from_utf8(stdout).context("git log output was not UTF-8")?;
+        Ok(text
+            .lines()
+            .filter_map(|line| line.split_once(' '))
+            .map(|(sha, date)| CommitRef {
+                sha: sha.to_string(),
+                date: date.to_string(),
             })
-        })
-        .collect()
+            .collect())
+    }
+
+    /// Read + parse `channel.json` at a commit straight from the local clone.
+    fn channel_info_at(&self, sha: &str) -> Result<ChannelInfo> {
+        let bytes = self
+            .cat_blob(sha, "channel.json")
+            .with_context(|| format!("reading channel.json at {sha}"))?;
+        #[derive(Deserialize)]
+        struct Wrapper {
+            info: ChannelInfo,
+        }
+        let wrapper: Wrapper = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing channel.json at {sha}"))?;
+        Ok(wrapper.info)
+    }
+
+    /// `git cat-file blob <sha>:<path>` — the bytes of a file at a commit.
+    fn cat_blob(&self, sha: &str, path: &str) -> Result<Vec<u8>> {
+        let spec = format!("{sha}:{path}");
+        git_in(&self.git_dir, &["cat-file", "blob", spec.as_str()])
+    }
 }
 
-/// Resolve a buildVersion to its mirror entry. Auto-detects the VS series
-/// from the version's major component. On miss, surfaces a few of the
-/// nearest available buildVersions for context.
-pub fn resolve_build_version(
-    urls: &MirrorUrls,
-    build_version: &str,
-    ctx: &InstallCtx,
-) -> Result<BuildIndexEntry> {
-    let major = build_version_major(build_version)?;
-    let vs = VsVersion::from_channel(major)?;
-    let entries = build_index(urls, &[vs], ctx)?;
-    if let Some(hit) = entries
-        .iter()
-        .find(|e| e.info.build_version == build_version)
-    {
-        return Ok(hit.clone());
-    }
-    let mut available: Vec<&str> = entries
-        .iter()
-        .map(|e| e.info.build_version.as_str())
-        .collect();
-    available.sort();
-    // Show 5 nearest (lex-closest) so the error fits on a terminal.
-    let suggestions: Vec<&&str> = available
-        .iter()
-        .filter(|v| v.starts_with(&format!("{major}.")))
-        .take(5)
-        .collect();
-    bail!(
-        "buildVersion '{build_version}' not found on {} (release-{major}); {} available; nearest: {}",
-        vs.as_str(),
-        available.len(),
-        if suggestions.is_empty() {
-            "(none)".to_string()
+/// Run `git <args>` and return stdout. Maps a missing `git` binary to a clear
+/// error; treats a non-zero exit as a failure carrying git's stderr.
+fn run_git(mut cmd: Command) -> Result<Vec<u8>> {
+    let out = cmd.output().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow!(
+                "`git` was not found on PATH; natron needs git to read the MSVC / Windows SDK manifest mirror"
+            )
         } else {
-            suggestions
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        },
-    )
+            anyhow!("spawning git: {e}")
+        }
+    })?;
+    if !out.status.success() {
+        bail!("git failed: {}", String::from_utf8_lossy(&out.stderr).trim());
+    }
+    Ok(out.stdout)
+}
+
+/// `git -C <dir> <args>`.
+fn git_in(dir: &Path, args: &[&str]) -> Result<Vec<u8>> {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(dir).args(args);
+    run_git(cmd)
+}
+
+/// Bare partial clone of `remote` into `dest` (a subdir of `meta_dir`). Clones
+/// into a unique temp dir under `meta_dir` then atomically renames it into
+/// place, so two concurrent natron runs can't corrupt a shared clone (same
+/// lock-free publish as the CAS).
+fn clone_into(remote: &str, dest: &Path, meta_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(meta_dir)
+        .with_context(|| format!("creating {}", meta_dir.display()))?;
+    let tmp = meta_dir.join(format!(".tmp-{}", uuid::Uuid::new_v4()));
+    let mut cmd = Command::new("git");
+    cmd.args(["clone", "--bare", "--filter=blob:limit=1m"])
+        .arg(remote)
+        .arg(&tmp);
+    if let Err(err) = run_git(cmd) {
+        let _ = fs_util::remove_dir_all_writable(&tmp);
+        return Err(err).with_context(|| format!("cloning manifest mirror from {remote}"));
+    }
+    if std::fs::rename(&tmp, dest).is_err() {
+        // A peer published the clone first; keep theirs, drop ours.
+        let _ = fs_util::remove_dir_all_writable(&tmp);
+    }
+    Ok(())
 }
 
 /// Parse the major component (first dot-segment) of a buildVersion.
@@ -422,29 +349,6 @@ pub fn build_version_major(build_version: &str) -> Result<u8> {
         .ok_or_else(|| anyhow!("buildVersion '{build_version}' is empty"))?;
     head.parse::<u8>()
         .map_err(|e| anyhow!("buildVersion '{build_version}' major is not numeric: {e}"))
-}
-
-// ---- HTTP helper -----------------------------------------------------------
-
-/// Plain GET. Used for the GitHub commits API — small JSON, no caching,
-/// must set a User-Agent (GitHub requires it).
-pub fn http_get(url: &str) -> Result<String> {
-    if let Some(rest) = url.strip_prefix("file://") {
-        // For test fixtures.
-        let p = url::Url::parse(url)
-            .ok()
-            .and_then(|u| u.to_file_path().ok())
-            .unwrap_or_else(|| std::path::PathBuf::from(rest));
-        return std::fs::read_to_string(&p)
-            .with_context(|| format!("reading file URL {}", p.display()));
-    }
-    let resp = crate::download::agent()
-        .get(url)
-        .header("User-Agent", USER_AGENT)
-        .header("Accept", "application/json")
-        .call()
-        .with_context(|| format!("GET {url}"))?;
-    Ok(resp.into_body().read_to_string()?)
 }
 
 #[cfg(test)]

--- a/src/providers/windows_sdk.rs
+++ b/src/providers/windows_sdk.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use xxhash_rust::xxh3::xxh3_64;
 
 use super::vs_manifest::{
-    self, BuildIndexEntry, MirrorUrls, Package, VsManifest, VsVersion,
+    self, BuildIndexEntry, ManifestHistory, Package, VsManifest, VsVersion,
 };
 use super::{InstallCtx, Installed, Provider};
 use crate::cache::sanitize_fingerprint;
@@ -110,18 +110,20 @@ fn is_numeric_sdk_version(s: &str) -> bool {
 // ---- provider --------------------------------------------------------------
 
 pub struct WindowsSdkProvider {
-    urls: MirrorUrls,
+    remote: String,
 }
 
 impl WindowsSdkProvider {
     pub fn new() -> Self {
         Self {
-            urls: MirrorUrls::default(),
+            remote: vs_manifest::default_remote(),
         }
     }
 
-    pub fn with_urls(urls: MirrorUrls) -> Self {
-        Self { urls }
+    pub fn with_remote(remote: impl Into<String>) -> Self {
+        Self {
+            remote: remote.into(),
+        }
     }
 }
 
@@ -149,7 +151,8 @@ impl Provider for WindowsSdkProvider {
             });
         }
 
-        let resolved = resolve_sdk_version(&self.urls, &opts.sdk_version, ctx)?;
+        let history = ManifestHistory::open(&self.remote, ctx.cache())?;
+        let resolved = resolve_sdk_version(&history, &opts.sdk_version)?;
         let component = lookup_exact(&resolved.manifest, &resolved.sdk_pkg_id)
             .ok_or_else(|| anyhow!("SDK component {} not in manifest", resolved.sdk_pkg_id))?;
         let dep_ids: Vec<String> = component.dependencies.keys().cloned().collect();
@@ -237,21 +240,21 @@ pub struct ResolvedSdk {
 /// `sdk_version`. Errors with the union of SDKs available across all three
 /// snapshots if nothing matches.
 pub fn resolve_sdk_version(
-    urls: &MirrorUrls,
+    history: &ManifestHistory,
     sdk_version: &str,
-    ctx: &InstallCtx,
 ) -> Result<ResolvedSdk> {
     let mut available: BTreeSet<String> = BTreeSet::new();
     let mut last_err: Option<anyhow::Error> = None;
     for vs in VsVersion::all().iter().rev() {
-        let entry = match newest_entry_for(urls, *vs, ctx) {
-            Ok(e) => e,
+        let entry = match history.newest(*vs) {
+            Ok(Some(e)) => e,
+            Ok(None) => continue,
             Err(err) => {
                 last_err = Some(err);
                 continue;
             }
         };
-        let manifest = match vs_manifest::fetch_manifest_at(&urls.raw_base, &entry.commit.sha, ctx) {
+        let manifest = match history.manifest(&entry.commit.sha) {
             Ok(m) => m,
             Err(err) => {
                 last_err = Some(err);
@@ -286,17 +289,18 @@ pub fn resolve_sdk_version(
 
 /// Distinct SDK versions discovered across the newest snapshot of each VS
 /// series. Sorted descending by numeric key.
-pub fn discover_sdk_versions(urls: &MirrorUrls, ctx: &InstallCtx) -> Result<Vec<String>> {
+pub fn discover_sdk_versions(history: &ManifestHistory) -> Result<Vec<String>> {
     let mut seen: BTreeSet<String> = BTreeSet::new();
     for vs in VsVersion::all() {
-        let entry = match newest_entry_for(urls, vs, ctx) {
-            Ok(e) => e,
+        let entry = match history.newest(vs) {
+            Ok(Some(e)) => e,
+            Ok(None) => continue,
             Err(err) => {
                 tracing::warn!("skipping {} for SDK discovery: {err:#}", vs.as_str());
                 continue;
             }
         };
-        let manifest = match vs_manifest::fetch_manifest_at(&urls.raw_base, &entry.commit.sha, ctx) {
+        let manifest = match history.manifest(&entry.commit.sha) {
             Ok(m) => m,
             Err(err) => {
                 tracing::warn!(
@@ -364,18 +368,6 @@ pub fn enumerate_msis(manifest: &VsManifest, sdk_pkg_id: &str) -> Result<Vec<(St
         }
     }
     Ok(out.into_iter().collect())
-}
-
-fn newest_entry_for(
-    urls: &MirrorUrls,
-    vs: VsVersion,
-    ctx: &InstallCtx,
-) -> Result<BuildIndexEntry> {
-    let entries = vs_manifest::build_index(urls, &[vs], ctx)?;
-    entries
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow!("no commits on mirror for {}", vs.as_str()))
 }
 
 // ---- selection -------------------------------------------------------------

--- a/src/tests/cache.rs
+++ b/src/tests/cache.rs
@@ -38,6 +38,7 @@ fn ensure_layout_creates_subdirs() {
     assert!(cache.cas.is_dir());
     assert!(cache.downloads.is_dir());
     assert!(cache.staging.is_dir());
+    assert!(cache.meta.is_dir());
 }
 
 #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -90,15 +90,15 @@ impl TestEnv {
     }
 
     /// Build a Natron with a default-style registry. The github provider's
-    /// api_base is set to a `file://` URL pointing at `<fixture_root>/api/`
-    /// so tests can pre-populate fake release JSON there. The zig provider's
+    /// download base is set to a `file://` URL pointing at `<fixture_root>/dl/`
+    /// so tests can pre-place release assets there. The zig provider's
     /// index_url points at `<fixture_root>/zig-index.json`; tests that use
     /// the zig provider must call `write_zig_index_json` first.
     pub fn make_natron(&self, cfg: Config) -> Natron {
         let cache = Cache::at(self.cache_dir.clone());
         let mut reg = ProviderRegistry::empty();
         reg.register(UrlProvider::new());
-        reg.register(GithubProvider::with_api_base(self.api_base()));
+        reg.register(GithubProvider::with_download_base(self.download_base()));
         reg.register(ZigProvider::with_index_url(self.zig_index_url()));
         Natron::new(cfg, cache, reg)
     }
@@ -141,37 +141,34 @@ impl TestEnv {
         std::fs::write(&path, json).unwrap();
     }
 
-    /// API base URL used by the github provider in tests. Format:
-    /// `file:///path/to/fixture_root/api` (no trailing slash).
-    pub fn api_base(&self) -> String {
-        let api_dir = self.fixture_root.join("api");
-        std::fs::create_dir_all(&api_dir).ok();
-        let url = url::Url::from_directory_path(&api_dir).unwrap().to_string();
+    /// Download base URL used by the github provider in tests. Format:
+    /// `file:///path/to/fixture_root/dl` (no trailing slash).
+    pub fn download_base(&self) -> String {
+        let dir = self.fixture_root.join("dl");
+        std::fs::create_dir_all(&dir).ok();
+        let url = url::Url::from_directory_path(&dir).unwrap().to_string();
         url.trim_end_matches('/').to_string()
     }
 
-    /// Pre-populate a fake GitHub release-info JSON. The asset's
-    /// browser_download_url points at the local archive.
-    pub fn write_github_release_json(
+    /// Pre-place a GitHub release asset where the provider builds its URL:
+    /// `<download_base>/{repo}/releases/download/{tag}/{asset}`.
+    pub fn place_github_asset(
         &self,
         repo: &str,
         tag: &str,
         asset_name: &str,
         archive_path: &Path,
     ) {
-        let api_dir = self.fixture_root.join("api");
-        let path = api_dir
-            .join("repos")
+        let dst = self
+            .fixture_root
+            .join("dl")
             .join(repo)
             .join("releases")
-            .join("tags")
-            .join(tag);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        let asset_url = url::Url::from_file_path(archive_path).unwrap().to_string();
-        let json = format!(
-            r#"{{"tag_name":"{tag}","assets":[{{"name":"{asset_name}","browser_download_url":"{asset_url}"}}]}}"#
-        );
-        std::fs::write(&path, json).unwrap();
+            .join("download")
+            .join(tag)
+            .join(asset_name);
+        std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        std::fs::copy(archive_path, &dst).unwrap();
     }
 
     /// Build a Natron with a caller-provided registry (lets tests inject
@@ -209,8 +206,8 @@ pub fn url_entry(name: &str, deploy_dir: &str, archive_path: &Path) -> Toolchain
 }
 
 /// Build a `[[toolchain]]` entry using `provider = "github"`. Caller is
-/// responsible for having pre-populated the matching release JSON via
-/// `TestEnv::write_github_release_json`.
+/// responsible for having pre-placed the matching asset via
+/// `TestEnv::place_github_asset`.
 pub fn github_entry(
     name: &str,
     deploy_dir: &str,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -417,8 +417,8 @@ fn test_install_github_provider() {
             ("LICENSE", b"llvm-license"),
         ],
     );
-    // Pre-populate the fake GitHub release JSON.
-    env.write_github_release_json(
+    // Pre-place the fake GitHub release asset.
+    env.place_github_asset(
         "llvm/llvm-project",
         "llvmorg-21.1.6",
         "clang+llvm-21.1.6-x86_64-pc-windows-msvc.tar.xz",
@@ -474,7 +474,7 @@ fn test_install_three_providers_at_once() {
         "zig-windows-x86_64-0.15.2.zip",
         &[("zig-windows-x86_64-0.15.2/zig.exe", b"ZIG")],
     );
-    env.write_github_release_json(
+    env.place_github_asset(
         "llvm/llvm-project",
         "llvmorg-21",
         "llvm.tar.xz",
@@ -619,15 +619,21 @@ fn test_real_github_llvm_install() {
 
 #[test]
 #[ignore = "network: requires upstream access (cargo test -- --ignored)"]
-fn test_real_mirror_commits_api() {
-    use natron::providers::vs_manifest::{self, MirrorUrls, VsVersion};
-    let urls = MirrorUrls::default();
+fn test_real_mirror_enumeration() {
+    // Partial-clone the live mirror and confirm each release branch yields
+    // at least one build. Exercises clone + `git log` + channel.json reads.
+    use natron::providers::vs_manifest::{self, ManifestHistory, VsVersion};
+    let env = TestEnv::new();
+    let cache = Cache::at(env.cache_dir.clone());
+    cache.ensure_layout().expect("cache layout");
+    let history = ManifestHistory::open(&vs_manifest::default_remote(), &cache).expect("open");
     for vs in VsVersion::all() {
-        let commits = vs_manifest::fetch_commits(&urls.commits_base, vs)
-            .unwrap_or_else(|e| panic!("commits for {}: {e:#}", vs.as_str()));
+        let entries = history
+            .index(&[vs])
+            .unwrap_or_else(|e| panic!("index for {}: {e:#}", vs.as_str()));
         assert!(
-            !commits.is_empty(),
-            "{} has zero commits on the mirror",
+            !entries.is_empty(),
+            "{} has zero builds on the mirror",
             vs.as_str()
         );
     }
@@ -641,19 +647,15 @@ fn test_real_msvc_primary_compiler() {
     // Microsoft renames the family or changes the .18.<minor>. structure,
     // this catches it.
     use natron::providers::msvc;
-    use natron::providers::vs_manifest::{self, MirrorUrls, VsVersion};
-    use natron::providers::InstallCtx;
+    use natron::providers::vs_manifest::{self, ManifestHistory, VsVersion};
     let env = TestEnv::new();
     let cache = Cache::at(env.cache_dir.clone());
     cache.ensure_layout().expect("cache layout");
-    let ctx = InstallCtx::new(cache);
-    let urls = MirrorUrls::default();
+    let history = ManifestHistory::open(&vs_manifest::default_remote(), &cache).expect("open");
 
-    let commits = vs_manifest::fetch_commits(&urls.commits_base, VsVersion::Vs2026)
-        .expect("commits");
-    let head_sha = &commits[0].sha;
-    let manifest = vs_manifest::fetch_manifest_at(&urls.raw_base, head_sha, &ctx)
-        .expect("manifest");
+    let entries = history.index(&[VsVersion::Vs2026]).expect("index");
+    let head_sha = &entries[0].commit.sha; // newest-first
+    let manifest = history.manifest(head_sha).expect("manifest");
     let primary = msvc::find_primary_compiler(&manifest, VsVersion::Vs2026)
         .expect("primary compiler");
     assert!(
@@ -667,16 +669,14 @@ fn test_real_msvc_primary_compiler() {
 #[test]
 #[ignore = "network: requires upstream access (cargo test -- --ignored)"]
 fn test_real_windows_sdk_versions() {
-    use natron::providers::vs_manifest::MirrorUrls;
+    use natron::providers::vs_manifest::{self, ManifestHistory};
     use natron::providers::windows_sdk;
-    use natron::providers::InstallCtx;
     let env = TestEnv::new();
     let cache = Cache::at(env.cache_dir.clone());
     cache.ensure_layout().expect("cache layout");
-    let ctx = InstallCtx::new(cache);
-    let urls = MirrorUrls::default();
+    let history = ManifestHistory::open(&vs_manifest::default_remote(), &cache).expect("open");
 
-    let versions = windows_sdk::discover_sdk_versions(&urls, &ctx).expect("discover");
+    let versions = windows_sdk::discover_sdk_versions(&history).expect("discover");
     assert!(
         !versions.is_empty(),
         "no Windows SDK versions discovered on the mirror"
@@ -688,19 +688,16 @@ fn test_real_windows_sdk_versions() {
 fn test_real_windows_sdk_packages() {
     // Resolve the newest SDK and confirm enumerate_msis returns at least
     // one default-installed MSI AND at least one extras-available MSI.
-    use natron::providers::vs_manifest::MirrorUrls;
+    use natron::providers::vs_manifest::{self, ManifestHistory};
     use natron::providers::windows_sdk;
-    use natron::providers::InstallCtx;
     let env = TestEnv::new();
     let cache = Cache::at(env.cache_dir.clone());
     cache.ensure_layout().expect("cache layout");
-    let ctx = InstallCtx::new(cache);
-    let urls = MirrorUrls::default();
+    let history = ManifestHistory::open(&vs_manifest::default_remote(), &cache).expect("open");
 
-    let versions = windows_sdk::discover_sdk_versions(&urls, &ctx).expect("discover");
+    let versions = windows_sdk::discover_sdk_versions(&history).expect("discover");
     let newest = versions.first().expect("at least one SDK").clone();
-    let resolved =
-        windows_sdk::resolve_sdk_version(&urls, &newest, &ctx).expect("resolve");
+    let resolved = windows_sdk::resolve_sdk_version(&history, &newest).expect("resolve");
     let msis = windows_sdk::enumerate_msis(&resolved.manifest, &resolved.sdk_pkg_id)
         .expect("enumerate");
     let default_count = msis.iter().filter(|(_, g)| g == "default").count();


### PR DESCRIPTION
## Summary

Three independent changes:

- **`cas`: publish blobs via non-destructive hardlink, not rename.** Two threads installing the same content raced in `cas_file`: `rename(staging -> cas_path)` overwrites on POSIX, churning a peer's already-published dentry and surfacing a transient `ENOENT` to a concurrent `hard_link`. Publish via `hard_link` (never overwrites) and dedupe on `AlreadyExists`. Fixes the flaky `sync_concurrent_threads_both_succeed`.

- **`download`: verify TLS against the OS trust store, not webpki-roots.** ureq validated server certs against compiled-in Mozilla roots, ignoring the system trust store / `SSL_CERT_FILE`. That broke every HTTPS fetch behind a TLS-inspecting proxy or with an enterprise CA. Enable ureq's `platform-verifier` and route requests through a shared agent using `RootCerts::PlatformVerifier`.

- **`providers`: read the VS manifest mirror via a git partial clone.** Replace all `api.github.com` usage so natron needs no GitHub token and never hits the 60-req/hr anonymous limit. The MSVC / Windows SDK providers maintain a local bare partial clone of the `roblabla/msvc-manifest-history` mirror (`git clone --filter=blob:limit=1m`, ~5 MB — defers the 15-25 MB `manifest.json` blobs to lazy promisor fetch). Modelled as a `ManifestHistory` handle: `open()` clones-or-fetches exactly once, then `index` / `resolve_build_version` / `manifest` are pure-local git reads — collapsing what used to be three `git fetch`es per `windows_sdk versions` into one. The clone lives at `<cache>/meta/msvc-manifest-history`. The `github` provider now builds the stable public release-asset URL directly instead of querying the releases API. `git` is a hard requirement, with a clear error if absent.

## Test plan

- [x] `cargo test` — 191 lib + 20 integration hermetic tests pass
- [x] `cargo test -- --include-ignored` — all 7 network tests pass (ziglang.org, GitHub release assets, and the roblabla mirror clone + `git log`/`cat-file` reads)
- [x] `cargo clippy --all-targets` — no new warnings (16 pre-existing, all in untouched files)
- [x] Live git-mirror tests confirm enumeration, MSVC primary-compiler resolution, and Windows SDK version discovery + MSI grouping against real upstream

https://claude.ai/code/session_015CwS4X7ni4n5SxxLBEg3g2

---
_Generated by [Claude Code](https://claude.ai/code/session_015CwS4X7ni4n5SxxLBEg3g2)_