### PR TITLE
Parallelize the sync pipeline (CAS, MSI/CAB, xz decode, toolchains)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -529,13 +531,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -566,6 +580,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -774,6 +794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +842,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+ "num_cpus",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,17 +897,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "lzxd"
@@ -914,6 +954,7 @@ dependencies = [
  "indicatif",
  "jwalk",
  "libc",
+ "liblzma",
  "msi",
  "serde",
  "serde_json",
@@ -928,7 +969,6 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "xxhash-rust",
- "xz2",
  "zip",
 ]
 
@@ -946,6 +986,16 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "number_prefix"
@@ -1049,6 +1099,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1194,7 +1250,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1856,7 +1912,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2212,15 +2268,6 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,11 @@ ureq = { version = "3.1.4", features = ["json", "platform-verifier"] }
 url = "2.5"
 uuid = { version = "1", features = ["v4"] }
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
-xz2 = "0.1"
+# liblzma (maintained successor to xz2) vendors liblzma 5.8 and exposes a
+# multithreaded .xz *decoder* (lzma_stream_decoder_mt), which xz2's bundled
+# 5.2 lacks. `static` builds the C from source on every platform (no system
+# liblzma needed); `parallel` enables the threaded codecs.
+liblzma = { version = "0.4", features = ["static", "parallel"] }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [target.'cfg(windows)'.dependencies]
@@ -56,5 +60,5 @@ sha2 = "0.10"
 tar = "0.4"
 toml = "0.8"
 url = "2.5"
-xz2 = "0.1"
+liblzma = { version = "0.4", features = ["static", "parallel"] }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -15,6 +15,8 @@ use anyhow::{Context, Result, anyhow};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::sync::Mutex;
+use std::sync::mpsc;
 
 use crate::cache::Cache;
 use crate::fs_util;
@@ -42,10 +44,18 @@ pub struct CasReport {
 /// tree at `staging_tree/` is what gets atomically renamed into
 /// `installs/<fingerprint>/tree/`.
 pub fn run(cache: &Cache, staging_raw: &Path, staging_tree: &Path) -> Result<CasReport> {
-    let mut report = CasReport::default();
     std::fs::create_dir_all(staging_tree)
         .with_context(|| format!("creating {}", staging_tree.display()))?;
 
+    // Walk once, partitioning entries by kind. Directories and symlinks are
+    // cheap and order-sensitive (parents before children), so we materialize
+    // them serially; the per-file CAS work (hash + two hardlinks + a readonly
+    // mark — the bulk of the cost, especially on Windows where each syscall is
+    // expensive and an AV scanner sits in the path) is dispatched to a worker
+    // pool below.
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut symlinks: Vec<(std::path::PathBuf, std::path::PathBuf)> = Vec::new();
+    let mut files: Vec<(std::path::PathBuf, std::path::PathBuf)> = Vec::new();
     for entry in jwalk::WalkDir::new(staging_raw)
         .skip_hidden(false)
         .follow_links(false)
@@ -60,22 +70,109 @@ pub fn run(cache: &Cache, staging_raw: &Path, staging_tree: &Path) -> Result<Cas
             continue;
         }
         let dst = staging_tree.join(rel);
-
         let ft = entry.file_type();
         if ft.is_dir() {
-            std::fs::create_dir_all(&dst)
-                .with_context(|| format!("mkdir {}", dst.display()))?;
-            report.directories += 1;
+            dirs.push(dst);
         } else if ft.is_symlink() {
-            reproduce_symlink(&src, &dst)?;
-            report.symlinks += 1;
+            symlinks.push((src, dst));
         } else if ft.is_file() {
-            cas_file(cache, &src, &dst, &mut report)?;
+            files.push((src, dst));
         }
         // Other file types (block/char/socket/fifo) are not expected in our
         // archives; ignore.
     }
+
+    let mut report = CasReport::default();
+    // `sort(true)` on the walk yields parents before children, so a plain
+    // create_dir_all per entry suffices to reproduce the tree skeleton.
+    for d in &dirs {
+        std::fs::create_dir_all(d)
+            .with_context(|| format!("mkdir {}", d.display()))?;
+    }
+    report.directories = dirs.len();
+    for (src, dst) in &symlinks {
+        reproduce_symlink(src, dst)?;
+    }
+    report.symlinks = symlinks.len();
+
+    let partials = cas_files_parallel(cache, &files)?;
+    for p in partials {
+        report.files_processed += p.files_processed;
+        report.dedupe_hits += p.dedupe_hits;
+        report.bytes_freed += p.bytes_freed;
+    }
     Ok(report)
+}
+
+/// Per-file CAS outcome accumulated by a worker.
+#[derive(Default)]
+struct FilePartial {
+    files_processed: usize,
+    dedupe_hits: usize,
+    bytes_freed: u64,
+}
+
+/// Process `files` (src -> dst pairs) through the CAS across a worker pool.
+/// Each CAS insertion is independently race-safe (see module docs: hardlink
+/// publish + byte-compare on EEXIST), so concurrent workers — both within this
+/// pass and against peer processes sharing the cache — can't corrupt a blob.
+fn cas_files_parallel(
+    cache: &Cache,
+    files: &[(std::path::PathBuf, std::path::PathBuf)],
+) -> Result<Vec<FilePartial>> {
+    if files.is_empty() {
+        return Ok(Vec::new());
+    }
+    let worker_count = crate::fs_util::worker_count(files.len());
+    if worker_count <= 1 {
+        let mut partial = FilePartial::default();
+        for (src, dst) in files {
+            cas_file(cache, src, dst, &mut partial)?;
+        }
+        return Ok(vec![partial]);
+    }
+
+    let queue: Mutex<Vec<usize>> = Mutex::new((0..files.len()).rev().collect());
+    let (tx, rx) = mpsc::channel::<Result<FilePartial>>();
+    std::thread::scope(|s| -> Result<Vec<FilePartial>> {
+        for _ in 0..worker_count {
+            let tx = tx.clone();
+            let queue = &queue;
+            s.spawn(move || {
+                let mut partial = FilePartial::default();
+                let result = loop {
+                    let idx = match queue.lock().unwrap().pop() {
+                        Some(i) => i,
+                        None => break Ok(partial),
+                    };
+                    let (src, dst) = &files[idx];
+                    if let Err(e) = cas_file(cache, src, dst, &mut partial) {
+                        // Drain the queue so peers stop pulling new work.
+                        queue.lock().unwrap().clear();
+                        break Err(e);
+                    }
+                };
+                let _ = tx.send(result);
+            });
+        }
+        drop(tx);
+        let mut partials = Vec::with_capacity(worker_count);
+        let mut first_err: Option<anyhow::Error> = None;
+        for msg in rx {
+            match msg {
+                Ok(p) => partials.push(p),
+                Err(e) => {
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+            }
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(partials),
+        }
+    })
 }
 
 /// Like `run` but skips CAS — moves staging files directly into the install
@@ -120,7 +217,7 @@ fn cas_file(
     cache: &Cache,
     src: &Path,
     dst: &Path,
-    report: &mut CasReport,
+    report: &mut FilePartial,
 ) -> Result<()> {
     let hex = hash_file_xxh3_128(src)?;
     let cas_path = cache.cas_path(&hex);
@@ -188,10 +285,11 @@ fn cas_file(
     fs_util::hard_link(&cas_path, dst)?;
 
     if just_inserted {
-        // Best-effort readonly on the CAS blob. The hardlink we just
-        // created shares the inode, so this also makes our install-tree
-        // entry readonly. Failure here is non-fatal.
-        let _ = fs_util::clear_readonly(&cas_path); // first clear in case set
+        // Best-effort readonly on the CAS blob. The hardlink we just created
+        // shares the inode, so this also makes our install-tree entry
+        // readonly. A blob we just published is a fresh hardlink off a
+        // writable, freshly-extracted file, so it's never already readonly —
+        // no need to clear first. Failure here is non-fatal.
         let _ = mark_readonly(&cas_path);
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -143,6 +143,22 @@ impl Natron {
         self.cache.ensure_layout()?;
         self.gc_stale_staging();
 
+        // deploy_dir must be unique per toolchain. Two entries deploying to
+        // the same path would clobber each other even serially; now that
+        // entries sync concurrently it is also a data race on that path.
+        // Reject it up front rather than corrupt a deploy tree.
+        {
+            let mut seen = HashSet::new();
+            for t in &self.config.toolchains {
+                if !seen.insert(t.deploy_dir.as_str()) {
+                    anyhow::bail!(
+                        "two toolchains share deploy_dir '{}'; deploy_dir must be unique per toolchain",
+                        t.deploy_dir
+                    );
+                }
+            }
+        }
+
         let mut state = DeployState::read(&self.config.resolved_deploy_dir())?;
 
         // Entries in state but not in config: clean their deploy dirs.
@@ -212,17 +228,20 @@ impl Natron {
                 let errors = &errors;
                 let outcomes = &outcomes;
                 s.spawn(move || loop {
-                    let wi = match queue.lock().unwrap().pop() {
+                    let wi = match queue.lock().unwrap_or_else(|e| e.into_inner()).pop() {
                         Some(i) => i,
                         None => return,
                     };
                     let (idx, entry) = work[wi];
                     match self.sync_entry(entry, state, opts) {
-                        Ok(outcome) => outcomes.lock().unwrap().push((idx, outcome)),
+                        Ok(outcome) => outcomes
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push((idx, outcome)),
                         Err(err) => {
                             let msg = format!("{err:#}");
                             tracing::error!("entry '{}' failed: {msg}", entry.name);
-                            errors.lock().unwrap().push(EntryError {
+                            errors.lock().unwrap_or_else(|e| e.into_inner()).push(EntryError {
                                 name: entry.name.clone(),
                                 message: msg,
                             });
@@ -232,12 +251,12 @@ impl Natron {
             }
         });
 
-        for (idx, outcome) in outcomes.into_inner().unwrap() {
+        for (idx, outcome) in outcomes.into_inner().unwrap_or_else(|e| e.into_inner()) {
             slots[idx] = Some(outcome);
         }
         report.entries = slots.into_iter().flatten().collect();
-        report.errors = errors.into_inner().unwrap();
-        let state = state.into_inner().unwrap();
+        report.errors = errors.into_inner().unwrap_or_else(|e| e.into_inner());
+        let state = state.into_inner().unwrap_or_else(|e| e.into_inner());
 
         if !opts.dry_run {
             state.write(&self.config.resolved_deploy_dir())?;
@@ -349,7 +368,7 @@ impl Natron {
         let deploy_path = deploy_root.join(&entry.deploy_dir);
         let install_tree = self.cache.install_tree(&fingerprint);
 
-        let diff = state.lock().unwrap().diff(
+        let diff = state.lock().unwrap_or_else(|e| e.into_inner()).diff(
             &entry.name,
             &fingerprint,
             &entry.deploy_dir,
@@ -368,7 +387,17 @@ impl Natron {
         }
 
         if let StateDiff::Drift { old_deploy_dir } = &diff {
-            if old_deploy_dir != &entry.deploy_dir {
+            // Reclaim the old path only if no *current* toolchain owns it.
+            // deploy_dirs are unique (validated in run), so if some entry's
+            // deploy_dir equals this old path, that peer is the legitimate
+            // owner and may be deploying there concurrently — undeploying it
+            // would delete a peer's fresh deployment.
+            let claimed_by_peer = self
+                .config
+                .toolchains
+                .iter()
+                .any(|t| &t.deploy_dir == old_deploy_dir);
+            if old_deploy_dir != &entry.deploy_dir && !claimed_by_peer {
                 let old_path = deploy_root.join(old_deploy_dir);
                 deploy::undeploy(&old_path).ok();
             }
@@ -383,7 +412,7 @@ impl Natron {
                 mode,
                 t_deploy.elapsed().as_secs_f64()
             );
-            state.lock().unwrap().upsert(
+            state.lock().unwrap_or_else(|e| e.into_inner()).upsert(
                 entry.name.clone(),
                 DeployedEntry {
                     fingerprint: fingerprint.clone(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -143,21 +143,9 @@ impl Natron {
         self.cache.ensure_layout()?;
         self.gc_stale_staging();
 
-        // deploy_dir must be unique per toolchain. Two entries deploying to
-        // the same path would clobber each other even serially; now that
-        // entries sync concurrently it is also a data race on that path.
-        // Reject it up front rather than corrupt a deploy tree.
-        {
-            let mut seen = HashSet::new();
-            for t in &self.config.toolchains {
-                if !seen.insert(t.deploy_dir.as_str()) {
-                    anyhow::bail!(
-                        "two toolchains share deploy_dir '{}'; deploy_dir must be unique per toolchain",
-                        t.deploy_dir
-                    );
-                }
-            }
-        }
+        // deploy_dir uniqueness (and non-emptiness) is already enforced by
+        // Config::validate at load time, so concurrent entries deploy to
+        // disjoint paths — we rely on that invariant rather than re-checking.
 
         let mut state = DeployState::read(&self.config.resolved_deploy_dir())?;
 
@@ -387,17 +375,18 @@ impl Natron {
         }
 
         if let StateDiff::Drift { old_deploy_dir } = &diff {
-            // Reclaim the old path only if no *current* toolchain owns it.
-            // deploy_dirs are unique (validated in run), so if some entry's
-            // deploy_dir equals this old path, that peer is the legitimate
-            // owner and may be deploying there concurrently — undeploying it
-            // would delete a peer's fresh deployment.
-            let claimed_by_peer = self
-                .config
-                .toolchains
-                .iter()
-                .any(|t| &t.deploy_dir == old_deploy_dir);
-            if old_deploy_dir != &entry.deploy_dir && !claimed_by_peer {
+            // Reclaim the path this entry drifted away from — but not if
+            // another entry that's actually being synced this run owns it
+            // (deploy_dirs are unique, so at most one does). That peer may be
+            // deploying there concurrently, and undeploying would delete its
+            // fresh deployment. If the owner isn't being synced, reclaiming the
+            // stale deployment is safe and correct.
+            let owned_by_active_peer = self.config.toolchains.iter().any(|t| {
+                &t.deploy_dir == old_deploy_dir
+                    && t.name != entry.name
+                    && (opts.only.is_empty() || opts.only.contains(&t.name))
+            });
+            if old_deploy_dir != &entry.deploy_dir && !owned_by_active_peer {
                 let old_path = deploy_root.join(old_deploy_dir);
                 deploy::undeploy(&old_path).ok();
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,6 +4,7 @@
 use anyhow::{Result, anyhow};
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Mutex;
 use std::time::SystemTime;
 
 use crate::cache::{Cache, InstallMetadata, sanitize_fingerprint};
@@ -17,6 +18,13 @@ use crate::state::{DeployState, DeployedEntry, StateDiff};
 /// Maximum age of a `staging/<uuid>/` dir, after which we GC it on `sync`
 /// startup. 60 minutes covers slow LLVM downloads (~1.5 GB).
 const STAGING_GC_THRESHOLD_SECS: u64 = 60 * 60;
+
+/// Upper bound on toolchains processed concurrently. Each entry already uses a
+/// core-sized worker pool internally (xz decode, CAB extraction, CAS), so this
+/// is deliberately small: enough to overlap one entry's network/git phase with
+/// another's CPU-bound decode, without multiplying the live thread count by the
+/// toolchain count.
+const MAX_CONCURRENT_TOOLCHAINS: usize = 4;
 
 /// Toplevel orchestrator. Holds the parsed config, resolved cache layout, a
 /// provider registry, and run-time options (dry-run, no-cas, mode override).
@@ -167,30 +175,69 @@ impl Natron {
             }
         }
 
+        // Partition entries into per-position outcome slots (filtered entries
+        // resolve immediately as Skipped) and a work list of the rest. Slots
+        // keep the report in config order regardless of completion order.
         let mut report = SyncReport::default();
-        for entry in &self.config.toolchains {
+        let mut slots: Vec<Option<EntryOutcome>> = vec![None; self.config.toolchains.len()];
+        let mut work: Vec<(usize, &ToolchainEntry)> = Vec::new();
+        for (i, entry) in self.config.toolchains.iter().enumerate() {
             if !opts.only.is_empty() && !opts.only.contains(&entry.name) {
-                report.entries.push(EntryOutcome {
+                slots[i] = Some(EntryOutcome {
                     name: entry.name.clone(),
                     fingerprint: String::new(),
                     display: String::new(),
                     mode: self.effective_mode(entry, opts),
                     action: SyncAction::Skipped,
                 });
-                continue;
-            }
-            match self.sync_entry(entry, &mut state, opts) {
-                Ok(outcome) => report.entries.push(outcome),
-                Err(err) => {
-                    let msg = format!("{err:#}");
-                    tracing::error!("entry '{}' failed: {msg}", entry.name);
-                    report.errors.push(EntryError {
-                        name: entry.name.clone(),
-                        message: msg,
-                    });
-                }
+            } else {
+                work.push((i, entry));
             }
         }
+
+        // Run toolchains concurrently so one's download/git phase overlaps
+        // another's CPU-bound decode. Each entry already saturates cores
+        // internally (parallel xz / CAB / CAS), so we cap toolchain-level
+        // concurrency low to overlap I/O without massively oversubscribing.
+        let state = Mutex::new(state);
+        let errors: Mutex<Vec<EntryError>> = Mutex::new(Vec::new());
+        let outcomes: Mutex<Vec<(usize, EntryOutcome)>> = Mutex::new(Vec::new());
+        let concurrency = MAX_CONCURRENT_TOOLCHAINS.min(work.len()).max(1);
+        let queue: Mutex<Vec<usize>> = Mutex::new((0..work.len()).rev().collect());
+        std::thread::scope(|s| {
+            for _ in 0..concurrency {
+                let queue = &queue;
+                let work = &work;
+                let state = &state;
+                let errors = &errors;
+                let outcomes = &outcomes;
+                s.spawn(move || loop {
+                    let wi = match queue.lock().unwrap().pop() {
+                        Some(i) => i,
+                        None => return,
+                    };
+                    let (idx, entry) = work[wi];
+                    match self.sync_entry(entry, state, opts) {
+                        Ok(outcome) => outcomes.lock().unwrap().push((idx, outcome)),
+                        Err(err) => {
+                            let msg = format!("{err:#}");
+                            tracing::error!("entry '{}' failed: {msg}", entry.name);
+                            errors.lock().unwrap().push(EntryError {
+                                name: entry.name.clone(),
+                                message: msg,
+                            });
+                        }
+                    }
+                });
+            }
+        });
+
+        for (idx, outcome) in outcomes.into_inner().unwrap() {
+            slots[idx] = Some(outcome);
+        }
+        report.entries = slots.into_iter().flatten().collect();
+        report.errors = errors.into_inner().unwrap();
+        let state = state.into_inner().unwrap();
 
         if !opts.dry_run {
             state.write(&self.config.resolved_deploy_dir())?;
@@ -218,7 +265,7 @@ impl Natron {
     fn sync_entry(
         &self,
         entry: &ToolchainEntry,
-        state: &mut DeployState,
+        state: &Mutex<DeployState>,
         opts: &SyncOptions,
     ) -> Result<EntryOutcome> {
         let provider = self.registry.require(&entry.provider)?;
@@ -251,7 +298,10 @@ impl Natron {
                 cas::run(&self.cache, &staging_raw, &staging_tree)?
             };
             let cas_elapsed = t_cas.elapsed().as_secs_f64();
-            let total_files = cas_report.files_processed + cas_report.dedupe_hits;
+            // files_processed already counts every regular file (dedupe hits
+            // included); dedupe_hits is the subset that matched an existing
+            // blob.
+            let total_files = cas_report.files_processed;
             tracing::info!(
                 "[timing] {} cas pass: {} files in {:.2}s ({:.0} files/s), dedupe_hits={} bytes_freed={}",
                 entry.name,
@@ -299,7 +349,7 @@ impl Natron {
         let deploy_path = deploy_root.join(&entry.deploy_dir);
         let install_tree = self.cache.install_tree(&fingerprint);
 
-        let diff = state.diff(
+        let diff = state.lock().unwrap().diff(
             &entry.name,
             &fingerprint,
             &entry.deploy_dir,
@@ -333,7 +383,7 @@ impl Natron {
                 mode,
                 t_deploy.elapsed().as_secs_f64()
             );
-            state.upsert(
+            state.lock().unwrap().upsert(
                 entry.name.clone(),
                 DeployedEntry {
                     fingerprint: fingerprint.clone(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -224,7 +224,13 @@ impl Natron {
         let provider = self.registry.require(&entry.provider)?;
         let mode = self.effective_mode(entry, opts);
         let mut ctx = InstallCtx::new(self.cache.clone());
+        let t_install = std::time::Instant::now();
         let installed = provider.install(&entry.options, &mut ctx)?;
+        tracing::info!(
+            "[timing] {} provider.install (download+extract) took {:.2}s",
+            entry.name,
+            t_install.elapsed().as_secs_f64()
+        );
         let raw_fp = installed.fingerprint;
         let fingerprint = sanitize_fingerprint(&raw_fp);
 
@@ -238,14 +244,20 @@ impl Natron {
             let staging_raw = staging_root.join("raw");
             let staging_tree = staging_root.join("tree");
 
+            let t_cas = std::time::Instant::now();
             let cas_report = if opts.no_cas {
                 cas::run_no_cas(&staging_raw, &staging_tree)?
             } else {
                 cas::run(&self.cache, &staging_raw, &staging_tree)?
             };
-            tracing::debug!(
-                "cas pass: files={} dedupe_hits={} bytes_freed={}",
-                cas_report.files_processed,
+            let cas_elapsed = t_cas.elapsed().as_secs_f64();
+            let total_files = cas_report.files_processed + cas_report.dedupe_hits;
+            tracing::info!(
+                "[timing] {} cas pass: {} files in {:.2}s ({:.0} files/s), dedupe_hits={} bytes_freed={}",
+                entry.name,
+                total_files,
+                cas_elapsed,
+                (total_files as f64) / cas_elapsed.max(0.0001),
                 cas_report.dedupe_hits,
                 cas_report.bytes_freed
             );
@@ -313,7 +325,14 @@ impl Natron {
         }
 
         let action = if diff.needs_redeploy() {
+            let t_deploy = std::time::Instant::now();
             deploy::deploy(&install_tree, &deploy_path, mode)?;
+            tracing::info!(
+                "[timing] {} deploy ({}) took {:.2}s",
+                entry.name,
+                mode,
+                t_deploy.elapsed().as_secs_f64()
+            );
             state.upsert(
                 entry.name.clone(),
                 DeployedEntry {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -91,8 +91,36 @@ fn extract_tar_xz(archive: &Path, dest: &Path, strip_prefix: Option<&str>) -> Re
     );
     let f = File::open(archive)
         .with_context(|| format!("opening {}", archive.display()))?;
-    let dec = xz2::read::XzDecoder::new(f);
+    let dec = mt_xz_decoder(f)?;
     extract_tar_inner(dec, dest, strip_prefix)
+}
+
+/// Build a multithreaded .xz decoder over `reader`. xz files written by `xz`
+/// (e.g. LLVM's release tarballs) are split into independent ~64 MiB blocks,
+/// so liblzma can decode them across threads. Falls back to a single-threaded
+/// auto-decoder if the MT decoder can't be initialized.
+fn mt_xz_decoder<R: std::io::Read>(reader: R) -> Result<liblzma::read::XzDecoder<R>> {
+    let threads = crate::fs_util::worker_count(usize::MAX) as u32;
+    if threads <= 1 {
+        return Ok(liblzma::read::XzDecoder::new(reader));
+    }
+    // memlimit_stop = MAX disables the hard decode limit; memlimit_threading is
+    // the soft budget below which liblzma keeps blocks single-threaded, so it
+    // must comfortably hold several in-flight 64 MiB blocks per worker.
+    let threading_budget = (threads as u64 + 1) * 256 * 1024 * 1024;
+    match liblzma::stream::MtStreamBuilder::new()
+        .threads(threads)
+        .memlimit_stop(u64::MAX)
+        .memlimit_threading(threading_budget)
+        .timeout_ms(0)
+        .decoder()
+    {
+        Ok(stream) => Ok(liblzma::read::XzDecoder::new_stream(reader, stream)),
+        Err(err) => {
+            tracing::warn!("MT xz decoder init failed ({err}); falling back to single-threaded");
+            Ok(liblzma::read::XzDecoder::new(reader))
+        }
+    }
 }
 
 fn extract_tar_gz(archive: &Path, dest: &Path, strip_prefix: Option<&str>) -> Result<()> {
@@ -114,6 +142,14 @@ fn extract_tar_gz(archive: &Path, dest: &Path, strip_prefix: Option<&str>) -> Re
     );
 }
 
+/// Files at or above this size are written inline on the reader thread
+/// (streamed, never buffered whole); smaller files are handed to the writer
+/// pool as an in-memory blob. This bounds the writer pool's memory to
+/// roughly `channel_capacity * THRESHOLD` while still parallelizing the many
+/// small-file creates — the per-file syscall + AV-scan cost that dominates on
+/// Windows.
+const TAR_INLINE_WRITE_THRESHOLD: u64 = 1 << 20; // 1 MiB
+
 fn extract_tar_inner<R: Read>(
     reader: R,
     dest: &Path,
@@ -121,66 +157,139 @@ fn extract_tar_inner<R: Read>(
 ) -> Result<()> {
     let mut archive = tar::Archive::new(reader);
     archive.set_overwrite(true);
-    for entry in archive.entries()? {
-        let mut entry = entry?;
-        let raw_path = entry.path()?.to_path_buf();
-        // Defend against tar-slip: reject absolute paths and `..` components.
-        if raw_path.is_absolute()
-            || raw_path
-                .components()
-                .any(|c| matches!(c, std::path::Component::ParentDir))
-        {
-            bail!("tar entry has unsafe path (tar-slip?): {}", raw_path.display());
+
+    let workers = crate::fs_util::worker_count(usize::MAX);
+    // tar is a sequential stream, so a single reader thread parses entries and
+    // either writes large files inline or dispatches small ones to the pool.
+    let (tx, rx) = std::sync::mpsc::sync_channel::<(PathBuf, Vec<u8>)>(workers * 4);
+    let rx = std::sync::Mutex::new(rx);
+    let first_err: std::sync::Mutex<Option<anyhow::Error>> = std::sync::Mutex::new(None);
+
+    std::thread::scope(|s| -> Result<()> {
+        for _ in 0..workers {
+            let rx = &rx;
+            let first_err = &first_err;
+            s.spawn(move || loop {
+                // Hold the lock only for the dequeue; the write happens after
+                // releasing it so workers write in parallel.
+                let job = {
+                    let guard = rx.lock().unwrap();
+                    guard.recv()
+                };
+                let (path, bytes) = match job {
+                    Ok(j) => j,
+                    Err(_) => return, // channel closed: no more work
+                };
+                if let Err(e) = write_file_bytes(&path, &bytes) {
+                    let mut g = first_err.lock().unwrap();
+                    if g.is_none() {
+                        *g = Some(e);
+                    }
+                }
+            });
         }
-        let rel = match apply_strip_prefix(&raw_path, strip_prefix) {
-            Some(r) => r,
-            None => continue,
-        };
-        if rel.as_os_str().is_empty() {
-            continue;
-        }
-        let out = dest.join(&rel);
-        let kind = entry.header().entry_type();
-        if kind.is_dir() {
-            std::fs::create_dir_all(&out)?;
-            continue;
-        }
-        if kind.is_symlink() {
-            // Reproduce as a symlink. The `tar` crate's unpack would do this;
-            // we replicate manually so strip_prefix works.
-            let link_target = entry
-                .link_name()?
-                .ok_or_else(|| anyhow!("symlink entry without link_name"))?
-                .into_owned();
-            if let Some(parent) = out.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            // Best-effort: skip if symlink already exists.
-            let _ = std::fs::remove_file(&out);
-            #[cfg(unix)]
-            {
-                std::os::unix::fs::symlink(&link_target, &out)?;
-            }
-            #[cfg(windows)]
-            {
-                // Windows: try a file symlink; fall back silently if not allowed.
-                if let Err(err) = std::os::windows::fs::symlink_file(&link_target, &out) {
-                    tracing::warn!(
-                        "could not create symlink {} -> {}: {err}",
-                        out.display(),
-                        link_target.display()
-                    );
+
+        let mut produce = || -> Result<()> {
+            for entry in archive.entries()? {
+                let mut entry = entry?;
+                let raw_path = entry.path()?.to_path_buf();
+                // Defend against tar-slip: reject absolute paths and `..`.
+                if raw_path.is_absolute()
+                    || raw_path
+                        .components()
+                        .any(|c| matches!(c, std::path::Component::ParentDir))
+                {
+                    bail!("tar entry has unsafe path (tar-slip?): {}", raw_path.display());
+                }
+                let rel = match apply_strip_prefix(&raw_path, strip_prefix) {
+                    Some(r) => r,
+                    None => continue,
+                };
+                if rel.as_os_str().is_empty() {
+                    continue;
+                }
+                let out = dest.join(&rel);
+                let kind = entry.header().entry_type();
+                if kind.is_dir() {
+                    std::fs::create_dir_all(&out)?;
+                    continue;
+                }
+                if kind.is_symlink() {
+                    let link_target = entry
+                        .link_name()?
+                        .ok_or_else(|| anyhow!("symlink entry without link_name"))?
+                        .into_owned();
+                    reproduce_tar_symlink(&out, &link_target)?;
+                    continue;
+                }
+                let size = entry.header().size().unwrap_or(0);
+                if size >= TAR_INLINE_WRITE_THRESHOLD {
+                    if let Some(parent) = out.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    let mut outf = File::create(&out)
+                        .with_context(|| format!("creating {}", out.display()))?;
+                    std::io::copy(&mut entry, &mut outf)
+                        .with_context(|| format!("writing {}", out.display()))?;
+                } else {
+                    let mut buf = Vec::with_capacity(size as usize);
+                    entry
+                        .read_to_end(&mut buf)
+                        .with_context(|| format!("reading {}", out.display()))?;
+                    // A send error means all workers died; surface their error.
+                    if tx.send((out, buf)).is_err() {
+                        break;
+                    }
+                }
+                // Bail early if a worker has already failed.
+                if first_err.lock().unwrap().is_some() {
+                    break;
                 }
             }
-            continue;
+            Ok(())
+        };
+
+        let result = produce();
+        drop(tx); // close the channel so workers drain and exit
+        result
+    })?;
+
+    if let Some(e) = first_err.into_inner().unwrap() {
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Write `bytes` to `path`, creating parent directories. Used by the tar
+/// writer pool. `create_dir_all` is race-tolerant across workers.
+fn write_file_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, bytes)
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+fn reproduce_tar_symlink(out: &Path, link_target: &Path) -> Result<()> {
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Best-effort: skip if symlink already exists.
+    let _ = std::fs::remove_file(out);
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(link_target, out)?;
+    }
+    #[cfg(windows)]
+    {
+        // Windows: try a file symlink; fall back silently if not allowed.
+        if let Err(err) = std::os::windows::fs::symlink_file(link_target, out) {
+            tracing::warn!(
+                "could not create symlink {} -> {}: {err}",
+                out.display(),
+                link_target.display()
+            );
         }
-        if let Some(parent) = out.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let mut outf = File::create(&out)
-            .with_context(|| format!("creating {}", out.display()))?;
-        std::io::copy(&mut entry, &mut outf)
-            .with_context(|| format!("writing {}", out.display()))?;
     }
     Ok(())
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -98,7 +98,8 @@ fn extract_tar_xz(archive: &Path, dest: &Path, strip_prefix: Option<&str>) -> Re
 /// Build a multithreaded .xz decoder over `reader`. xz files written by `xz`
 /// (e.g. LLVM's release tarballs) are split into independent ~64 MiB blocks,
 /// so liblzma can decode them across threads. Falls back to a single-threaded
-/// auto-decoder if the MT decoder can't be initialized.
+/// stream decoder (the same flags=0 decoder the old `xz2` path used) if the MT
+/// decoder can't be initialized.
 fn mt_xz_decoder<R: std::io::Read>(reader: R) -> Result<liblzma::read::XzDecoder<R>> {
     let threads = crate::fs_util::worker_count(usize::MAX) as u32;
     if threads <= 1 {

--- a/src/extract_msi.rs
+++ b/src/extract_msi.rs
@@ -56,6 +56,9 @@ enum CabSource {
 struct CabUnit {
     source: CabSource,
     cab_name: String,
+    /// Source MSI filename, kept for error/progress context (which MSI a
+    /// failing CAB came from).
+    msi_name: String,
     jobs: Vec<ExtractJob>,
 }
 
@@ -90,6 +93,10 @@ fn plan_msi(msi: &Path, dest: &Path) -> Result<Vec<CabUnit>> {
     let jobs_by_cab = enumerate_files(&mut package, &components, &dir_paths, &media)
         .with_context(|| format!("enumerating File rows from {}", msi.display()))?;
 
+    let msi_name = msi
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| msi.display().to_string());
     let mut units = Vec::with_capacity(jobs_by_cab.len());
     for (cab_name, jobs) in jobs_by_cab {
         let source = if let Some(stream_name) = cab_name.strip_prefix('#') {
@@ -103,6 +110,7 @@ fn plan_msi(msi: &Path, dest: &Path) -> Result<Vec<CabUnit>> {
         units.push(CabUnit {
             source,
             cab_name,
+            msi_name: msi_name.clone(),
             jobs,
         });
     }
@@ -397,10 +405,11 @@ fn extract_cab<R: Read + Seek>(reader: R, jobs: &[ExtractJob], cab_name: &str) -
 /// references dozens of external sibling CABs) gives hundreds of evenly-sized
 /// work units that keep all cores busy.
 ///
-/// CABs may safely write to the same `dest` concurrently — files land under
-/// their `Directory`-table paths, and the rare case where two CABs touch the
-/// same path (a header shared across components) writes identical content, so
-/// last-writer-wins is benign.
+/// Destination paths are deduplicated across all CABs before extraction, so a
+/// file shared across components/MSIs is extracted once (first occurrence in
+/// MSI order wins, deterministically). That removes redundant work AND the
+/// only concurrency hazard — two workers writing the same path at once, which
+/// `File::create` + `io::copy` would tear rather than cleanly last-writer-win.
 ///
 /// On the first failure: drains the queue so in-flight workers exit after
 /// their current task, then returns the error.
@@ -417,23 +426,45 @@ pub fn extract_msis_in_parallel(msis: &[PathBuf], dest: &Path) -> Result<()> {
             .with_context(|| format!("planning MSI {}", msi.display()))?;
         units.append(&mut planned);
     }
+
+    // Dedup destination paths across all CABs (see fn-doc): keep the first job
+    // to claim each path, drop the rest, then drop any CAB left with no work.
+    {
+        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+        for unit in &mut units {
+            unit.jobs.retain(|job| seen.insert(job.dest_path.clone()));
+        }
+        units.retain(|u| !u.jobs.is_empty());
+    }
+
     let total = units.len();
     if total == 0 {
         return Ok(());
     }
     tracing::info!("extracting {total} CABs across {} MSIs", msis.len());
 
+    // Log at info on ~10 evenly-spaced milestones so a long extraction shows
+    // continuous progress without one line per CAB.
+    let step = (total / 10).max(1);
+    let log_progress = |done: usize, unit: &CabUnit| {
+        if done % step == 0 || done == total {
+            tracing::info!("[{done}/{total}] extracted CAB {} ({})", unit.cab_name, unit.msi_name);
+        }
+    };
+
     let worker_count = crate::fs_util::worker_count(total);
     if worker_count <= 1 {
-        for unit in &units {
-            extract_cab_unit(unit)
-                .with_context(|| format!("extracting CAB {}", unit.cab_name))?;
+        for (i, unit) in units.iter().enumerate() {
+            extract_cab_unit(unit).with_context(|| {
+                format!("extracting CAB {} from {}", unit.cab_name, unit.msi_name)
+            })?;
+            log_progress(i + 1, unit);
         }
         return Ok(());
     }
 
     let queue: Mutex<Vec<usize>> = Mutex::new((0..total).rev().collect());
-    let (tx, rx) = mpsc::channel::<Result<()>>();
+    let (tx, rx) = mpsc::channel::<(usize, Result<()>)>();
 
     std::thread::scope(|s| -> Result<()> {
         for _ in 0..worker_count {
@@ -441,14 +472,15 @@ pub fn extract_msis_in_parallel(msis: &[PathBuf], dest: &Path) -> Result<()> {
             let queue = &queue;
             let units = &units;
             s.spawn(move || loop {
-                let idx = match queue.lock().unwrap().pop() {
+                let idx = match queue.lock().unwrap_or_else(|e| e.into_inner()).pop() {
                     Some(i) => i,
                     None => return,
                 };
                 let unit = &units[idx];
-                let result = extract_cab_unit(unit)
-                    .with_context(|| format!("extracting CAB {}", unit.cab_name));
-                if tx.send(result).is_err() {
+                let result = extract_cab_unit(unit).with_context(|| {
+                    format!("extracting CAB {} from {}", unit.cab_name, unit.msi_name)
+                });
+                if tx.send((idx, result)).is_err() {
                     return;
                 }
             });
@@ -458,13 +490,16 @@ pub fn extract_msis_in_parallel(msis: &[PathBuf], dest: &Path) -> Result<()> {
         // Cancel = drain the queue so in-flight workers exit after their
         // current task instead of grinding through every remaining job
         // before scope() can join.
-        let cancel = || queue.lock().unwrap().clear();
+        let cancel = || queue.lock().unwrap_or_else(|e| e.into_inner()).clear();
 
-        for msg in rx {
+        let mut done = 0usize;
+        for (idx, msg) in rx {
             if let Err(e) = msg {
                 cancel();
                 return Err(e);
             }
+            done += 1;
+            log_progress(done, &units[idx]);
         }
         Ok(())
     })

--- a/src/extract_msi.rs
+++ b/src/extract_msi.rs
@@ -34,6 +34,34 @@ const FILE_ATTR_NONCOMPRESSED: i32 = 0x2000;
 /// callers (e.g. `windows_sdk` install) manage scratch dirs themselves.
 pub fn extract_msi(msi: &Path, dest: &Path) -> Result<()> {
     tracing::debug!("extract_msi {} -> {}", msi.display(), dest.display());
+    let units = plan_msi(msi, dest)?;
+    for unit in &units {
+        extract_cab_unit(unit)?;
+    }
+    Ok(())
+}
+
+/// Where a CAB's bytes live: a loose sibling file on disk, or a `#CabN`
+/// stream embedded inside the MSI itself.
+enum CabSource {
+    External(PathBuf),
+    Embedded { msi: PathBuf, stream: String },
+}
+
+/// One unit of extraction work: a single CAB plus the files to pull from it.
+/// CABs are the natural parallelism granularity — each is an independent
+/// compressed container — and a single SDK MSI typically references dozens of
+/// external CABs, so planning at this level lets the worker pool saturate all
+/// cores instead of bottlenecking on one giant MSI.
+struct CabUnit {
+    source: CabSource,
+    cab_name: String,
+    jobs: Vec<ExtractJob>,
+}
+
+/// Read an MSI's tables and resolve its file layout into a list of per-CAB
+/// extraction units, without touching any CAB bytes. Cheap (metadata only).
+fn plan_msi(msi: &Path, dest: &Path) -> Result<Vec<CabUnit>> {
     std::fs::create_dir_all(dest)
         .with_context(|| format!("creating {}", dest.display()))?;
 
@@ -62,21 +90,45 @@ pub fn extract_msi(msi: &Path, dest: &Path) -> Result<()> {
     let jobs_by_cab = enumerate_files(&mut package, &components, &dir_paths, &media)
         .with_context(|| format!("enumerating File rows from {}", msi.display()))?;
 
+    let mut units = Vec::with_capacity(jobs_by_cab.len());
     for (cab_name, jobs) in jobs_by_cab {
-        if let Some(stream_name) = cab_name.strip_prefix('#') {
-            let stream = package.read_stream(stream_name).with_context(|| {
-                format!("opening embedded CAB stream {cab_name} in {}", msi.display())
-            })?;
-            extract_cab(stream, &jobs, &cab_name)?;
+        let source = if let Some(stream_name) = cab_name.strip_prefix('#') {
+            CabSource::Embedded {
+                msi: msi.to_path_buf(),
+                stream: stream_name.to_string(),
+            }
         } else {
-            let cab_path = msi_dir.join(&cab_name);
-            let cab_file = File::open(&cab_path)
+            CabSource::External(msi_dir.join(&cab_name))
+        };
+        units.push(CabUnit {
+            source,
+            cab_name,
+            jobs,
+        });
+    }
+    Ok(units)
+}
+
+/// Open a unit's CAB and stream its files out to their resolved dest paths.
+fn extract_cab_unit(unit: &CabUnit) -> Result<()> {
+    match &unit.source {
+        CabSource::External(cab_path) => {
+            let cab_file = File::open(cab_path)
                 .with_context(|| format!("opening external CAB {}", cab_path.display()))?;
-            extract_cab(cab_file, &jobs, &cab_name)?;
+            extract_cab(cab_file, &unit.jobs, &unit.cab_name)
+        }
+        CabSource::Embedded { msi, stream } => {
+            // Re-open the MSI per embedded unit so units stay independent and
+            // Send-able across worker threads. SDK MSIs use external sibling
+            // CABs, so this path is rarely hit.
+            let mut package = msi::open(msi)
+                .with_context(|| format!("re-opening MSI {} for embedded CAB", msi.display()))?;
+            let reader = package.read_stream(stream).with_context(|| {
+                format!("opening embedded CAB stream #{stream} in {}", msi.display())
+            })?;
+            extract_cab(reader, &unit.jobs, &unit.cab_name)
         }
     }
-
-    Ok(())
 }
 
 // ---- table readers ---------------------------------------------------------
@@ -337,51 +389,65 @@ fn extract_cab<R: Read + Seek>(reader: R, jobs: &[ExtractJob], cab_name: &str) -
 
 // ---- batch / parallel extraction -------------------------------------------
 
-/// Worker pool size for parallel batch MSI extraction. Matches the
-/// vsix-extractor's `EXTRACT_PARALLELISM` in `src/cli/msvc.rs`.
-const EXTRACT_PARALLELISM: usize = 16;
-
-/// Extract every MSI in `msis` into the shared `dest` directory, in
-/// parallel across a small worker pool. Each MSI emits one info-level
-/// `tracing` line as it starts so users see continuous progress instead
-/// of a silent multi-minute pause.
+/// Extract every MSI in `msis` into the shared `dest` directory, parallelized
+/// across a worker pool at **CAB granularity** rather than per-MSI. SDK MSIs
+/// vary wildly in size (a CRT-sources MSI dwarfs a header MSI), so a per-MSI
+/// pool leaves cores idle once the small MSIs finish; planning every MSI into
+/// its constituent CABs first (each an independent container, and one MSI
+/// references dozens of external sibling CABs) gives hundreds of evenly-sized
+/// work units that keep all cores busy.
 ///
-/// MSIs may safely write to the same `dest` concurrently — each one
-/// lays files out under its own `Directory`-table paths, and the few
-/// cases where two MSIs touch the same path (rare; SDK installers
-/// occasionally share a header file across components) the content is
-/// identical so the last writer wins benignly.
+/// CABs may safely write to the same `dest` concurrently — files land under
+/// their `Directory`-table paths, and the rare case where two CABs touch the
+/// same path (a header shared across components) writes identical content, so
+/// last-writer-wins is benign.
 ///
-/// On the first per-MSI failure: drains the queue so in-flight workers
-/// exit after their current task, then returns the error.
+/// On the first failure: drains the queue so in-flight workers exit after
+/// their current task, then returns the error.
 pub fn extract_msis_in_parallel(msis: &[PathBuf], dest: &Path) -> Result<()> {
-    let total = msis.len();
+    if msis.is_empty() {
+        return Ok(());
+    }
+
+    // Plan phase: read each MSI's tables (metadata only — fast) and flatten
+    // into one big list of per-CAB units.
+    let mut units: Vec<CabUnit> = Vec::new();
+    for msi in msis {
+        let mut planned = plan_msi(msi, dest)
+            .with_context(|| format!("planning MSI {}", msi.display()))?;
+        units.append(&mut planned);
+    }
+    let total = units.len();
     if total == 0 {
         return Ok(());
     }
+    tracing::info!("extracting {total} CABs across {} MSIs", msis.len());
+
+    let worker_count = crate::fs_util::worker_count(total);
+    if worker_count <= 1 {
+        for unit in &units {
+            extract_cab_unit(unit)
+                .with_context(|| format!("extracting CAB {}", unit.cab_name))?;
+        }
+        return Ok(());
+    }
+
     let queue: Mutex<Vec<usize>> = Mutex::new((0..total).rev().collect());
     let (tx, rx) = mpsc::channel::<Result<()>>();
-    let worker_count = EXTRACT_PARALLELISM.min(total);
 
     std::thread::scope(|s| -> Result<()> {
         for _ in 0..worker_count {
             let tx = tx.clone();
-            // See cli/msvc.rs::extract_in_parallel for the rationale on
-            // rebinding the Mutex by reference for the `move` closure.
             let queue = &queue;
+            let units = &units;
             s.spawn(move || loop {
                 let idx = match queue.lock().unwrap().pop() {
                     Some(i) => i,
                     None => return,
                 };
-                let msi = &msis[idx];
-                let name = msi
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| msi.display().to_string());
-                tracing::info!("[{}/{total}] extracting {name}", idx + 1);
-                let result = extract_msi(msi, dest)
-                    .with_context(|| format!("extracting MSI {}", msi.display()));
+                let unit = &units[idx];
+                let result = extract_cab_unit(unit)
+                    .with_context(|| format!("extracting CAB {}", unit.cab_name));
                 if tx.send(result).is_err() {
                     return;
                 }

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -317,17 +317,16 @@ pub fn latest_inside_mtime(dir: &Path) -> Result<std::time::SystemTime> {
 }
 
 /// Worker-pool size for a batch of `items` units of work: the machine's
-/// parallelism, capped at 16 and never more than the number of items. Returns
-/// at least 1. Centralizes the sizing used by the CAS pass and the archive
-/// extractors so they all scale with the host rather than a hardcoded count.
+/// parallelism, capped at 16 and never more than the number of items. Always
+/// returns at least 1 (even for an empty batch), so a caller that sizes both
+/// its worker loop and a bounded channel from this value can't accidentally
+/// spawn zero workers and deadlock its producer. Centralizes the sizing used
+/// by the CAS pass and the archive extractors so they scale with the host.
 pub fn worker_count(items: usize) -> usize {
-    if items <= 1 {
-        return items;
-    }
     let cores = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);
-    cores.clamp(1, 16).min(items)
+    cores.clamp(1, 16).min(items.max(1))
 }
 
 /// Return forward-slash version of a path (best-effort UTF-8). Used when

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -316,6 +316,20 @@ pub fn latest_inside_mtime(dir: &Path) -> Result<std::time::SystemTime> {
     Ok(latest)
 }
 
+/// Worker-pool size for a batch of `items` units of work: the machine's
+/// parallelism, capped at 16 and never more than the number of items. Returns
+/// at least 1. Centralizes the sizing used by the CAS pass and the archive
+/// extractors so they all scale with the host rather than a hardcoded count.
+pub fn worker_count(items: usize) -> usize {
+    if items <= 1 {
+        return items;
+    }
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    cores.clamp(1, 16).min(items)
+}
+
 /// Return forward-slash version of a path (best-effort UTF-8). Used when
 /// serializing paths into TOML / JSON state files.
 pub fn slash_str(path: &Path) -> String {

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -98,18 +98,28 @@ impl Provider for GithubProvider {
             tag,
             asset,
         );
+        let t_dl = std::time::Instant::now();
         let archive_path = ctx
             .download(&asset_url, sha256)
             .with_context(|| format!("downloading {asset} from {asset_url}"))?;
+        tracing::info!(
+            "[timing] github {asset}: download took {:.2}s",
+            t_dl.elapsed().as_secs_f64()
+        );
 
         // Extract into the staging dir.
         let staging_raw = ctx.staging_dir()?;
+        let t_ex = std::time::Instant::now();
         extract::extract_archive(
             &archive_path,
             archive_kind,
             &staging_raw,
             strip_prefix.as_deref(),
         )?;
+        tracing::info!(
+            "[timing] github {asset}: extract took {:.2}s",
+            t_ex.elapsed().as_secs_f64()
+        );
 
         Ok(Installed {
             fingerprint,

--- a/src/providers/msvc.rs
+++ b/src/providers/msvc.rs
@@ -148,9 +148,14 @@ impl Provider for MsvcProvider {
             });
         }
 
+        let t_git = std::time::Instant::now();
         let history = ManifestHistory::open(&self.remote, ctx.cache())?;
         let entry = history.resolve_build_version(&opts.build_version)?;
         let manifest = history.manifest(&entry.commit.sha)?;
+        tracing::info!(
+            "[timing] msvc: git manifest open+resolve+load took {:.2}s",
+            t_git.elapsed().as_secs_f64()
+        );
         let compiler = find_primary_compiler(&manifest, entry.vs)
             .with_context(|| format!("locating primary compiler for build {}", opts.build_version))?;
         let family = family_prefix(&compiler.id)?;
@@ -159,25 +164,37 @@ impl Provider for MsvcProvider {
         let staging = ctx.staging_dir()?;
         let mut downloaded_count = 0usize;
         let mut cached_count = 0usize;
+        let mut dl_secs = 0.0f64;
+        let mut ex_secs = 0.0f64;
         for request in &selected {
             let pkg = lookup_package(&manifest, request)?;
             for payload in &pkg.payloads {
                 let filename = payload_filename(payload);
+                let t_dl = std::time::Instant::now();
                 let (archive, source) = ctx
                     .download_with_outcome(&payload.url, payload.sha256.as_deref())
                     .with_context(|| format!("downloading {filename} for {}", pkg.id))?;
+                dl_secs += t_dl.elapsed().as_secs_f64();
                 match source {
                     FetchSource::Cached => cached_count += 1,
                     FetchSource::Downloaded => downloaded_count += 1,
                 }
+                let t_ex = std::time::Instant::now();
                 extract_payload(&archive, &filename, &staging)
                     .with_context(|| format!("extracting {filename} for {}", pkg.id))?;
+                ex_secs += t_ex.elapsed().as_secs_f64();
             }
         }
         tracing::info!(
             "msvc build {}: {downloaded_count} payloads downloaded, \
              {cached_count} already cached",
             opts.build_version,
+        );
+        tracing::info!(
+            "[timing] msvc: {} payloads, serial download {:.2}s + serial extract {:.2}s",
+            downloaded_count + cached_count,
+            dl_secs,
+            ex_secs
         );
 
         Ok(Installed {

--- a/src/providers/vs_manifest.rs
+++ b/src/providers/vs_manifest.rs
@@ -164,6 +164,10 @@ impl ManifestHistory {
     /// down) leaves the existing clone usable. Requires `git` on PATH.
     pub fn open(remote: &str, cache: &Cache) -> Result<Self> {
         let git_dir = cache.meta.join(MIRROR_REPO);
+        // Hold the lock across the is_dir check + clone/fetch: a concurrent
+        // peer that loses the race then observes the published clone and just
+        // fetches, instead of both cold-cache opens cloning the mirror twice.
+        let _guard = meta_git_lock().lock().unwrap_or_else(|e| e.into_inner());
         if git_dir.is_dir() {
             let _ = git_in(&git_dir, &["fetch", "--quiet", "origin"]);
         } else {
@@ -304,8 +308,25 @@ impl ManifestHistory {
     /// `git cat-file blob <sha>:<path>` — the bytes of a file at a commit.
     fn cat_blob(&self, sha: &str, path: &str) -> Result<Vec<u8>> {
         let spec = format!("{sha}:{path}");
+        // `cat-file` lazily fetches blobs the partial clone filtered out
+        // (notably the big manifest.json) from the promisor remote. Serialize
+        // so concurrent providers don't collide on git's pack/index lock and
+        // fail with an opaque "git failed". Local-blob reads (channel.json)
+        // pay only a cheap uncontended lock.
+        let _guard = meta_git_lock().lock().unwrap_or_else(|e| e.into_inner());
         git_in(&self.git_dir, &["cat-file", "blob", spec.as_str()])
     }
+}
+
+/// Serializes git operations on the shared mirror clone under `<cache>/meta`.
+/// The `msvc` and `windows_sdk` providers can sync concurrently and share this
+/// one clone; without serialization two cold-cache opens double-clone, and
+/// concurrent `git fetch` / promisor `cat-file` fetches collide on git's
+/// pack/index/ref lockfiles. In-process only — cross-process contention is
+/// left to git's own locking, as before this change.
+fn meta_git_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
 }
 
 /// Run `git <args>` and return stdout. Maps a missing `git` binary to a clear

--- a/src/providers/windows_sdk.rs
+++ b/src/providers/windows_sdk.rs
@@ -152,8 +152,13 @@ impl Provider for WindowsSdkProvider {
             });
         }
 
+        let t_git = std::time::Instant::now();
         let history = ManifestHistory::open(&self.remote, ctx.cache())?;
         let resolved = resolve_sdk_version(&history, &opts.sdk_version)?;
+        tracing::info!(
+            "[timing] windows_sdk: git manifest open+resolve took {:.2}s",
+            t_git.elapsed().as_secs_f64()
+        );
         let component = lookup_exact(&resolved.manifest, &resolved.sdk_pkg_id)
             .ok_or_else(|| anyhow!("SDK component {} not in manifest", resolved.sdk_pkg_id))?;
         let dep_ids: Vec<String> = component.dependencies.keys().cloned().collect();
@@ -174,6 +179,7 @@ impl Provider for WindowsSdkProvider {
         std::fs::create_dir_all(&extract_dir)
             .with_context(|| format!("creating {}", extract_dir.display()))?;
 
+        let t_dl = std::time::Instant::now();
         let mut msis_to_extract: Vec<std::path::PathBuf> = Vec::new();
         let mut downloaded_count = 0usize;
         let mut cached_count = 0usize;
@@ -234,9 +240,20 @@ impl Provider for WindowsSdkProvider {
              {cached_count} already cached",
             opts.sdk_version,
         );
+        tracing::info!(
+            "[timing] windows_sdk: serial download+stage of {} payloads took {:.2}s",
+            downloaded_count + cached_count,
+            t_dl.elapsed().as_secs_f64()
+        );
         tracing::info!("extracting {} SDK MSIs", msis_to_extract.len());
+        let t_ex = std::time::Instant::now();
         extract::extract_msis_in_parallel(&msis_to_extract, &extract_dir)
             .context("extracting SDK MSIs")?;
+        tracing::info!(
+            "[timing] windows_sdk: parallel MSI extract ({} MSIs) took {:.2}s",
+            msis_to_extract.len(),
+            t_ex.elapsed().as_secs_f64()
+        );
         flatten_windows_kits_into(&extract_dir, &staging_raw)
             .context("flattening Windows Kits/10")?;
         let _ = fs_util::remove_dir_all_writable(&payloads_dir);

--- a/src/tests/extract.rs
+++ b/src/tests/extract.rs
@@ -18,7 +18,7 @@ fn build_zip(path: &Path, entries: &[(&str, &[u8])]) {
 
 fn build_tar_xz(path: &Path, entries: &[(&str, &[u8])]) {
     let f = File::create(path).unwrap();
-    let enc = xz2::write::XzEncoder::new(f, 0);
+    let enc = liblzma::write::XzEncoder::new(f, 0);
     let mut tar = tar::Builder::new(enc);
     for (name, data) in entries {
         let mut header = tar::Header::new_gnu();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,7 +57,7 @@ impl TestEnv {
     pub fn make_tar_xz(&self, name: &str, entries: &[(&str, &[u8])]) -> PathBuf {
         let path = self.fixture_root.join(name);
         let f = File::create(&path).unwrap();
-        let enc = xz2::write::XzEncoder::new(f, 0);
+        let enc = liblzma::write::XzEncoder::new(f, 0);
         let mut tar = tar::Builder::new(enc);
         for (entry_name, bytes) in entries {
             let mut header = tar::Header::new_gnu();


### PR DESCRIPTION
## Summary

`cargo run --release --example anubis_demo` was slow (~10 min on Windows). Profiling showed the cold-cache cost is almost entirely **archive decompression**, with a single-threaded CAS pass that's cheap on Linux but expensive on Windows (per-file syscalls + Defender scanning every open/hardlink/attribute write).

This branch parallelizes the hot paths. On a **4-core** box the demo's cold-cache wall time drops **289s → 105s (2.75×)**; the gains scale further on higher core counts, and the CAS/small-file-write changes specifically target the Windows-only overhead that doesn't show up on Linux.

### Profiling instrumentation (commit 1)
`[timing]` info logs around the expensive phases (`provider.install` with a download/extract split, the CAS pass with files/s, deploy) so the per-phase breakdown is visible per toolchain — run on Windows to get the definitive numbers for that machine.

### Optimizations (commit 2)
- **Parallel CAS** (`cas.rs`): process files across a worker pool instead of one at a time. CAS insertion is already race-safe (hardlink publish + byte-compare on `EEXIST`), so concurrent workers — and peer processes — can't corrupt a blob. Also drop the redundant `clear_readonly` before `mark_readonly` on freshly-published blobs (a fresh hardlink off a writable file is never already readonly).
- **Multithreaded xz decode** (`extract.rs`, `Cargo.toml`): swap the unmaintained `xz2` (bundles liblzma 5.2, encoder-only MT) for the maintained `liblzma` crate (5.8) and decode `.xz` across threads via `lzma_stream_decoder_mt`. `static` vendors the C on every platform, so **no new system dependency** (same build requirement as before; the `bindgen` feature uses checked-in bindings, no libclang). LLVM extract **87s → 25s**.
- **Parallel tar writes** (`extract.rs`): small files written from a bounded worker pool, large files streamed inline — parallelizes the many small-file creates (the per-file syscall + AV cost that dominates on Windows) without unbounded memory.
- **CAB-granularity MSI parallelism** (`extract_msi.rs`): parallelize across CABs spanning all MSIs rather than per-MSI, since SDK MSIs vary wildly in size and each references dozens of external CABs. SDK extract **165s → 91s**.
- **Concurrent toolchains** (`engine.rs`): run toolchains concurrently (bounded by `MAX_CONCURRENT_TOOLCHAINS`) behind a `Mutex<DeployState>` so one entry's download/git phase overlaps another's decode. Report stays in config order.
- **`worker_count()`** (`fs_util.rs`): shared helper so every parallel section scales with the host (cores, capped at 16).

Hash-on-extract was considered and **deliberately deferred** — it would couple four extractors and break on the SDK's post-extract file renames (`flatten_windows_kits_into`), for a small win once the CAS pass is parallel.

## Test plan
- [x] `cargo test` — 199 + 20 passing, 0 failed
- [x] Cold-cache `anubis_demo`: all five toolchains install correctly (every well-known binary `OK`, no errors); 289s → 105s on 4 cores
- [x] Warm-cache `anubis_demo`: 0.003s, all `up-to-date` (fast path intact)
- [ ] Confirm on Windows: run the instrumented release build and check the `[timing]` CAS `files/s` and extract numbers on a real multi-core + Defender machine

https://claude.ai/code/session_015A3Fzf1zxh3rSsMd7TrJRs

---
_Generated by [Claude Code](https://claude.ai/code/session_015A3Fzf1zxh3rSsMd7TrJRs)_